### PR TITLE
Allowing SGE schedulers to use the plugin

### DIFF
--- a/aiida_kkr/parsers/kkr.py
+++ b/aiida_kkr/parsers/kkr.py
@@ -35,11 +35,11 @@ class KkrParser(Parser):
 
         self._ParserVersion = __version__
 
-        #reuse init of base class
+        # reuse init of base class
         super(KkrParser, self).__init__(calc)
 
-
     # pylint: disable=protected-access
+
     def parse(self, debug=False, **kwargs):
         """
         Parse output data folder, store results in database.
@@ -67,8 +67,9 @@ class KkrParser(Parser):
 
         # we need at least the output file name as defined in calcs.py
         if KkrCalculation._DEFAULT_OUTPUT_FILE not in list_of_files:
-            msg = "Output file '{}' not found in list of files: {}".format(KkrCalculation._DEFAULT_OUTPUT_FILE, list_of_files)
-            if self.icrit==0: # this check turns this off for the KKRimporter calculation
+            msg = "Output file '{}' not found in list of files: {}".format(
+                KkrCalculation._DEFAULT_OUTPUT_FILE, list_of_files)
+            if self.icrit == 0:  # this check turns this off for the KKRimporter calculation
                 self.logger.error(msg)
                 return self.exit_codes.ERROR_NO_OUTPUT_FILE
 
@@ -78,7 +79,7 @@ class KkrParser(Parser):
         with out_folder.open(KkrCalculation._INPUT_FILE_NAME) as file:
             txt = file.readlines()
             itmp = search_string('RUNOPT', txt)
-            if itmp>=0:
+            if itmp >= 0:
                 runopts = txt[itmp+1]
                 if 'qdos' in runopts:
                     skip_mode = True
@@ -106,14 +107,16 @@ class KkrParser(Parser):
             with out_folder.open(fname) as fhandle:
                 outfile_0init = fhandle.name
         else:
-            file_errors.append((1+self.icrit, "Critical error! OUTPUT_0_INIT not found {}".format(fname)))
+            file_errors.append(
+                (1+self.icrit, "Critical error! OUTPUT_0_INIT not found {}".format(fname)))
             outfile_0init = None
         fname = KkrCalculation._OUTPUT_000
         if fname in out_folder.list_object_names():
             with out_folder.open(fname) as fhandle:
                 outfile_000 = fhandle.name
         else:
-            file_errors.append((1+self.icrit, "Critical error! OUTPUT_000 not found {}".format(fname)))
+            file_errors.append(
+                (1+self.icrit, "Critical error! OUTPUT_000 not found {}".format(fname)))
             outfile_000 = None
         fname = KkrCalculation._OUTPUT_2
         if fname in out_folder.list_object_names():
@@ -121,7 +124,8 @@ class KkrParser(Parser):
                 outfile_2 = fhandle.name
         else:
             if not only_000_present:
-                file_errors.append((1+self.icrit, "Critical error! OUTPUT_2 not found {}".format(fname)))
+                file_errors.append(
+                    (1+self.icrit, "Critical error! OUTPUT_2 not found {}".format(fname)))
                 outfile_2 = None
             else:
                 outfile_2 = outfile_000
@@ -130,27 +134,30 @@ class KkrParser(Parser):
             with out_folder.open(fname) as fhandle:
                 potfile_out = fhandle.name
         else:
-            file_errors.append((1+self.icrit, "Critical error! OUT_POTENTIAL not found {}".format(fname)))
+            file_errors.append(
+                (1+self.icrit, "Critical error! OUT_POTENTIAL not found {}".format(fname)))
             potfile_out = None
         fname = KkrCalculation._OUT_TIMING_000
         if fname in out_folder.list_object_names():
             with out_folder.open(fname) as fhandle:
                 timing_file = fhandle.name
         else:
-            file_errors.append((1+self.icrit, "Critical error! OUT_TIMING_000  not found {}".format(fname)))
+            file_errors.append(
+                (1+self.icrit, "Critical error! OUT_TIMING_000  not found {}".format(fname)))
             timing_file = None
         fname = KkrCalculation._NONCO_ANGLES_OUT
         if fname in out_folder.list_object_names():
             with out_folder.open(fname) as fhandle:
                 nonco_out_file = fhandle.name
         else:
-            file_errors.append((2, "Error! NONCO_ANGLES_OUT not found {}".format(fname)))
+            file_errors.append(
+                (2, "Error! NONCO_ANGLES_OUT not found {}".format(fname)))
             nonco_out_file = None
 
         out_dict = {'parser_version': self._ParserVersion,
                     'calculation_plugin_version': KkrCalculation._CALCULATION_PLUGIN_VERSION}
 
-        #TODO job title, compound description
+        # TODO job title, compound description
 
         success, msg_list, out_dict = parse_kkr_outputfile(out_dict, outfile,
                                                            outfile_0init, outfile_000,
@@ -164,24 +171,24 @@ class KkrParser(Parser):
             # try second combination of files
             out_dict2 = out_dict.copy()
             success2, msg_list2, out_dict2 = parse_kkr_outputfile(out_dict2, outfile_2,
-                outfile_0init, outfile_000, timing_file, potfile_out, nonco_out_file,
-                outfile_2, skip_readin=skip_mode)
+                                                                  outfile_0init, outfile_000, timing_file, potfile_out, nonco_out_file,
+                                                                  outfile_2, skip_readin=skip_mode)
             self.logger.info('msg_list1: {}'.format(msg_list2))
-            if len(msg_list2)<len(msg_list): # overwrite parser outputs if fewer errors
+            if len(msg_list2) < len(msg_list):  # overwrite parser outputs if fewer errors
                 self.logger.info('take output of parser run 1')
                 success, msg_list, out_dict = success2, msg_list2, out_dict2
             # try third combination of files
             out_dict2 = out_dict.copy()
             success2, msg_list2, out_dict2 = parse_kkr_outputfile(out_dict2, outfile_000,
-                outfile_0init, outfile_000, timing_file, potfile_out, nonco_out_file,
-                outfile_2, skip_readin=skip_mode)
+                                                                  outfile_0init, outfile_000, timing_file, potfile_out, nonco_out_file,
+                                                                  outfile_2, skip_readin=skip_mode)
             self.logger.info('msg_list2: {}'.format(msg_list2))
-            if len(msg_list2)<len(msg_list): # overwrite parser outputs if fewer errors
+            if len(msg_list2) < len(msg_list):  # overwrite parser outputs if fewer errors
                 self.logger.info('take output of parser run 2')
                 success, msg_list, out_dict = success2, msg_list2, out_dict2
 
         out_dict['parser_errors'] = msg_list
-         # add file open errors to parser output of error messages
+        # add file open errors to parser output of error messages
         for (err_cat, f_err) in file_errors:
             if err_cat == 1:
                 msg_list.append(f_err)
@@ -190,25 +197,25 @@ class KkrParser(Parser):
             else:
                 if 'parser_warnings' not in list(out_dict.keys()):
                     out_dict['parser_warnings'] = []
-                out_dict['parser_warnings'].append(f_err.replace('Error', 'Warning'))
+                out_dict['parser_warnings'].append(
+                    f_err.replace('Error', 'Warning'))
         out_dict['parser_errors'] = msg_list
 
-        #create output node and link
+        # create output node and link
         self.out('output_parameters', Dict(dict=out_dict))
 
-        if self.icrit != 0 and not success: # overwrite behavior with KKRimporter
-            success = True # set automatically to True even if only partial output was parsed
+        if self.icrit != 0 and not success:  # overwrite behavior with KKRimporter
+            success = True  # set automatically to True even if only partial output was parsed
             msg = "Automatically returned success=True for KKR importer although some parsing errors occurred"
             self.logger.warning(msg)
 
         if not success:
             return self.exit_codes.ERROR_KKR_PARSING_FAILED
-        else: # cleanup after parsing (only if parsing was successful)
+        else:  # cleanup after parsing (only if parsing was successful)
             # delete completely parsed output files
             self.remove_unnecessary_files()
             # then (maybe) tar the output to save space
-            #TODO needs implementing (see kkrimp parser)
-
+            # TODO needs implementing (see kkrimp parser)
 
     def remove_unnecessary_files(self):
         """

--- a/aiida_kkr/parsers/kkrimp.py
+++ b/aiida_kkr/parsers/kkrimp.py
@@ -38,11 +38,11 @@ class KkrimpParser(Parser):
 
         self._ParserVersion = __version__
 
-        #reuse init of base class
+        # reuse init of base class
         super(KkrimpParser, self).__init__(calc)
 
-
     # pylint: disable=protected-access
+
     def parse(self, debug=False, **kwargs):
         """
         Parse output data folder, store results in database.
@@ -74,24 +74,25 @@ class KkrimpParser(Parser):
         #    out_dict values (e.g. nspin, newsosol, ...)
 
         if KkrimpCalculation._DEFAULT_OUTPUT_FILE not in list_of_files:
-            msg = "Output file '{}' not found in list of files: {}".format(KkrimpCalculation._DEFAULT_OUTPUT_FILE, list_of_files)
-        
-    
+            msg = "Output file '{}' not found in list of files: {}".format(
+                KkrimpCalculation._DEFAULT_OUTPUT_FILE, list_of_files)
+
         if KkrimpCalculation._DEFAULT_OUTPUT_FILE in out_folder.list_object_names():
             with out_folder.open(KkrimpCalculation._DEFAULT_OUTPUT_FILE) as fhandle:
                 outfile = fhandle.name
             files['outfile'] = outfile
         else:
-            file_errors.append((1,msg))
+            file_errors.append((1, msg))
             outfile = None
-            
+
         fname = KkrimpCalculation._OUTPUT_000
         if fname in out_folder.list_object_names():
             with out_folder.open(fname) as fhandle:
                 filepath = fhandle.name
             files['out_log'] = filepath
         else:
-            file_errors.append((1, "Critical error! file '{}' not found ".format(fname)))
+            file_errors.append(
+                (1, "Critical error! file '{}' not found ".format(fname)))
             files['out_log'] = None
         fname = KkrimpCalculation._OUT_POTENTIAL
         if fname in out_folder.list_object_names():
@@ -99,7 +100,8 @@ class KkrimpParser(Parser):
                 filepath = fhandle.name
             files['out_pot'] = filepath
         else:
-            file_errors.append((1, "Critical error! file '{}' not found ".format(fname)))
+            file_errors.append(
+                (1, "Critical error! file '{}' not found ".format(fname)))
             files['out_pot'] = None
         fname = KkrimpCalculation._OUT_TIMING_000
         if fname in out_folder.list_object_names():
@@ -107,15 +109,17 @@ class KkrimpParser(Parser):
                 filepath = fhandle.name
             files['out_timing'] = filepath
         else:
-            file_errors.append((1, "Critical error! file '{}' not found ".format(fname)))
-            files['out_timing'] = None 
+            file_errors.append(
+                (1, "Critical error! file '{}' not found ".format(fname)))
+            files['out_timing'] = None
         fname = KkrimpCalculation._OUT_ENERGYSP_PER_ATOM
         if fname in out_folder.list_object_names():
             with out_folder.open(fname) as fhandle:
                 filepath = fhandle.name
             files['out_enersp_at'] = filepath
         else:
-            file_errors.append((1, "Critical error! file '{}' not found ".format(fname)))
+            file_errors.append(
+                (1, "Critical error! file '{}' not found ".format(fname)))
             files['out_enersp_at'] = None
         fname = KkrimpCalculation._OUT_ENERGYTOT_PER_ATOM
         if fname in out_folder.list_object_names():
@@ -123,7 +127,8 @@ class KkrimpParser(Parser):
                 filepath = fhandle.name
             files['out_enertot_at'] = filepath
         else:
-            file_errors.append((1, "Critical error! file '{}' not found ".format(fname)))
+            file_errors.append(
+                (1, "Critical error! file '{}' not found ".format(fname)))
             files['out_enertot_at'] = None
         fname = KkrimpCalculation._KKRFLEX_LLYFAC
         if fname in out_folder.list_object_names():
@@ -131,7 +136,8 @@ class KkrimpParser(Parser):
                 filepath = fhandle.name
             files['kkrflex_llyfac'] = filepath
         else:
-            file_errors.append((2, "Warning! file '{}' not found ".format(fname)))
+            file_errors.append(
+                (2, "Warning! file '{}' not found ".format(fname)))
             files['kkrflex_llyfac'] = None
         fname = KkrimpCalculation._KKRFLEX_ANGLE
         if fname in out_folder.list_object_names():
@@ -139,7 +145,8 @@ class KkrimpParser(Parser):
                 filepath = fhandle.name
             files['kkrflex_angles'] = filepath
         else:
-            file_errors.append((2, "Warning! file '{}' not found ".format(fname)))
+            file_errors.append(
+                (2, "Warning! file '{}' not found ".format(fname)))
             files['kkrflex_angles'] = None
         fname = KkrimpCalculation._OUT_MAGNETICMOMENTS
         if fname in out_folder.list_object_names():
@@ -147,7 +154,8 @@ class KkrimpParser(Parser):
                 filepath = fhandle.name
             files['out_spinmoms'] = filepath
         else:
-            file_errors.append((2, "Warning! file '{}' not found ".format(fname)))
+            file_errors.append(
+                (2, "Warning! file '{}' not found ".format(fname)))
             files['out_spinmoms'] = None
         fname = KkrimpCalculation._OUT_ORBITALMOMENTS
         if fname in out_folder.list_object_names():
@@ -155,7 +163,8 @@ class KkrimpParser(Parser):
                 filepath = fhandle.name
             files['out_orbmoms'] = filepath
         else:
-            file_errors.append((2, "Warning! file '{}' not found ".format(fname)))
+            file_errors.append(
+                (2, "Warning! file '{}' not found ".format(fname)))
             files['out_orbmoms'] = None
 
         if debug:
@@ -165,10 +174,11 @@ class KkrimpParser(Parser):
         out_dict = {'parser_version': self._ParserVersion,
                     'calculation_plugin_version': KkrimpCalculation._CALCULATION_PLUGIN_VERSION}
 
-        success, msg_list, out_dict = KkrimpParserFunctions().parse_kkrimp_outputfile(out_dict, files, debug=debug)
+        success, msg_list, out_dict = KkrimpParserFunctions(
+        ).parse_kkrimp_outputfile(out_dict, files, debug=debug)
 
         out_dict['parser_errors'] = msg_list
-         # add file open errors to parser output of error messages
+        # add file open errors to parser output of error messages
         for (err_cat, f_err) in file_errors:
             if err_cat == 1:
                 msg_list.append(f_err)
@@ -177,16 +187,18 @@ class KkrimpParser(Parser):
             else:
                 if 'parser_warnings' not in list(out_dict.keys()):
                     out_dict['parser_warnings'] = []
-                out_dict['parser_warnings'].append(f_err.replace('Error', 'Warning'))
+                out_dict['parser_warnings'].append(
+                    f_err.replace('Error', 'Warning'))
         out_dict['parser_errors'] = msg_list
 
-        #create output node and link
+        # create output node and link
         self.out('output_parameters', Dict(dict=out_dict))
 
         # cleanup after parsing (only if parsing was successful)
         if success:
             # reduce size of timing file
-            self.cleanup_outfiles(files['out_timing'], ['Iteration number', 'time until scf starts'])
+            self.cleanup_outfiles(files['out_timing'], [
+                                  'Iteration number', 'time until scf starts'])
             # reduce size of out_log file
             self.cleanup_outfiles(files['out_log'], ['Iteration Number'])
             # delete completely parsed output files and create a tar ball to reduce size
@@ -195,22 +207,22 @@ class KkrimpParser(Parser):
         else:
             return self.exit_codes.ERROR_PARSING_KKRIMPCALC
 
-
     def cleanup_outfiles(self, fileidentifier, keyslist):
         """open file and remove unneeded output"""
         lineids = []
         with open_general(fileidentifier) as tfile:
             txt = tfile.readlines()
             for iline in range(len(txt)):
-                for key in keyslist: # go through all keys
-                    if key in txt[iline]: # add line id to list if key has been found
+                for key in keyslist:  # go through all keys
+                    if key in txt[iline]:  # add line id to list if key has been found
                         lineids.append(iline)
         # rewrite file deleting the middle part
-        if len(lineids)>1: # cut only if more than one iteration was found
-            txt = txt[:lineids[0]] + ['# ... [removed output except for last iteration] ...\n'] + txt[lineids[-1]:]
+        if len(lineids) > 1:  # cut only if more than one iteration was found
+            txt = txt[:lineids[0]] + \
+                ['# ... [removed output except for last iteration] ...\n'] + \
+                txt[lineids[-1]:]
             with open_general(fileidentifier, 'w') as tfilenew:
                 tfilenew.writelines(txt)
-
 
     def remove_unnecessary_files(self):
         """
@@ -226,7 +238,6 @@ class KkrimpParser(Parser):
             if fileid in self.retrieved.list_object_names():
                 self.retrieved.delete_object(fileid, force=True)
 
-
     def final_cleanup(self):
         """Create a tarball of the rest."""
 
@@ -241,7 +252,7 @@ class KkrimpParser(Parser):
             # first create dummy file which is used to extract the full path that is given to tarfile.open
             with ret.open(KkrimpCalculation._FILENAME_TAR, 'w') as f:
                 filepath_tar = f.name
-           
+
             # now create tarfile and loop over content of retrieved directory
             to_delete = []
             with tarfile.open(filepath_tar, 'w:gz') as tf:
@@ -249,13 +260,15 @@ class KkrimpParser(Parser):
                     with ret.open(f) as ftest:
                         filesize = os.stat(ftest.name).st_size
                         ffull = ftest.name
-                    if (f != KkrimpCalculation._FILENAME_TAR  # ignore tar file
-                        and filesize>0                        # ignore empty files
-                        and f[0]!='.'):                       # ignore files starting with '.' like '.nfs...'
+                    if (
+                        f != KkrimpCalculation._FILENAME_TAR    # ignore tar file
+                        and filesize > 0                        # ignore empty files
+                        # ignore files starting with '.' like '.nfs...'
+                        and f[0] != '.'
+                    ):
                         tf.add(ffull, arcname=os.path.basename(ffull))
                         to_delete.append(f)
 
             # finally delete files that have been added to tarfile
             for f in to_delete:
                 ret.delete_object(f, force=True)
- 

--- a/aiida_kkr/parsers/voro.py
+++ b/aiida_kkr/parsers/voro.py
@@ -1,4 +1,4 @@
-#-*- coding: utf-8 -*-
+# -*- coding: utf-8 -*-
 
 from __future__ import absolute_import
 from aiida.parsers.parser import Parser
@@ -26,13 +26,15 @@ class VoronoiParser(Parser):
         Initialize the instance of Voronoi_Parser
         """
         # these files should be present after success of voronoi
-        self._default_files = {'outfile': VoronoiCalculation._OUTPUT_FILE_NAME,
-                               'atominfo': VoronoiCalculation._ATOMINFO,
-                               'radii': VoronoiCalculation._RADII}
+        self._default_files = {
+            'outfile': VoronoiCalculation._OUTPUT_FILE_NAME,
+            'atominfo': VoronoiCalculation._ATOMINFO,
+            'radii': VoronoiCalculation._RADII
+        }
 
         self._ParserVersion = __version__
 
-        #reuse init of base class
+        # reuse init of base class
         super(VoronoiParser, self).__init__(calc)
 
     # pylint: disable=protected-access
@@ -59,10 +61,13 @@ class VoronoiParser(Parser):
 
         # we need at least the output file name as defined in calcs.py
         if VoronoiCalculation._OUTPUT_FILE_NAME not in list_of_files:
-            self.logger.error("Output file '{}' not found".format(VoronoiCalculation._OUTPUT_FILE_NAME))
+            self.logger.error(
+                "Output file '{}' not found"
+                .format(VoronoiCalculation._OUTPUT_FILE_NAME)
+            )
             return self.exit_codes.ERROR_NO_OUTPUT_FILE
 
-        #Parse voronoi output, results that are stored in database are in out_dict
+        # Parse voronoi output, results that are stored in database are in out_dict
 
         # get path to files and catch errors if files are not present
         file_errors = []
@@ -75,47 +80,60 @@ class VoronoiParser(Parser):
                 with out_folder.open(VoronoiCalculation._POTENTIAL_IN_OVERWRITE) as fhandle:
                     potfile = fhandle.name
             else:
-                file_errors.append("Critical error! Neither potfile {}  not {} "
-                                   "was found".format(VoronoiCalculation._OUT_POTENTIAL_voronoi,
-                                                      VoronoiCalculation._POTENTIAL_IN_OVERWRITE))
+                file_errors.append(
+                    "Critical error! Neither potfile {}  not {} "
+                    "was found"
+                    .format(VoronoiCalculation._OUT_POTENTIAL_voronoi,
+                            VoronoiCalculation._POTENTIAL_IN_OVERWRITE)
+                )
                 potfile = 'file_not_found'
         if VoronoiCalculation._OUTPUT_FILE_NAME in out_folder.list_object_names():
             with out_folder.open(VoronoiCalculation._OUTPUT_FILE_NAME) as fhandle:
                 outfile = fhandle.name
         else:
-            file_errors.append("Critical error! outfile not found {}".format(VoronoiCalculation._OUTPUT_FILE_NAME))
+            file_errors.append(
+                "Critical error! outfile not found {}"
+                .format(VoronoiCalculation._OUTPUT_FILE_NAME)
+            )
             outfile = 'file_not_found'
         if VoronoiCalculation._ATOMINFO in out_folder.list_object_names():
             with out_folder.open(VoronoiCalculation._ATOMINFO) as fhandle:
                 atominfo = fhandle.name
         else:
-            file_errors.append("Critical error! atominfo not found {}".format(VoronoiCalculation._ATOMINFO))
+            file_errors.append(
+                "Critical error! atominfo not found {}"
+                .format(VoronoiCalculation._ATOMINFO)
+            )
             atominfo = 'file_not_found'
         if VoronoiCalculation._RADII in out_folder.list_object_names():
             with out_folder.open(VoronoiCalculation._RADII) as fhandle:
                 radii = fhandle.name
         else:
-            file_errors.append("Critical error! radii not found {}".format(VoronoiCalculation._RADII))
+            file_errors.append("Critical error! radii not found {}".format(
+                VoronoiCalculation._RADII))
             radii = 'file_not_found'
         if VoronoiCalculation._INPUT_FILE_NAME in out_folder.list_object_names():
             with out_folder.open(VoronoiCalculation._INPUT_FILE_NAME) as fhandle:
                 inputfile = fhandle.name
         else:
-            file_errors.append("Critical error! inputfile not found {}".format(VoronoiCalculation._INPUT_FILE_NAME))
+            file_errors.append(
+                "Critical error! inputfile not found {}"
+                .format(VoronoiCalculation._INPUT_FILE_NAME)
+            )
             inputfile = 'file_not_found'
         # initialize out_dict and parse output files
         out_dict = {'parser_version': self._ParserVersion}
         out_dict['calculation_plugin_version'] = VoronoiCalculation._CALCULATION_PLUGIN_VERSION
-        #TODO add job description, compound name, calculation title
-        success, msg_list, out_dict = parse_voronoi_output(out_dict, outfile,
-                                                           potfile, atominfo,
-                                                           radii, inputfile, debug=debug)
+        # TODO add job description, compound name, calculation title
+        success, msg_list, out_dict = parse_voronoi_output(
+            out_dict, outfile, potfile, atominfo, radii, inputfile, debug=debug
+        )
         # add file open errors to parser output of error messages
         for f_err in file_errors:
             msg_list.append(f_err)
         out_dict['parser_errors'] = msg_list
 
-        #create output node and link
+        # create output node and link
         self.out('output_parameters', Dict(dict=out_dict))
 
         if not success:

--- a/aiida_kkr/tools/common_workfunctions.py
+++ b/aiida_kkr/tools/common_workfunctions.py
@@ -18,6 +18,7 @@ from builtins import str
 # keys that are used by aiida-kkr some something else than KKR parameters
 _ignored_keys = ['ef_set', 'use_input_alat']
 
+
 @calcfunction
 def update_params_wf(parameternode, updatenode, **link_inputs):
     """
@@ -49,7 +50,7 @@ def update_params_wf(parameternode, updatenode, **link_inputs):
         nodedesc = None
 
     # do nothing if updatenode is empty
-    if len(list(updatenode_dict.keys()))==0:
+    if len(list(updatenode_dict.keys())) == 0:
         print('Input node is empty, do nothing!')
         raise InputValidationError('Nothing to store in input')
     #
@@ -79,13 +80,15 @@ def update_params(node, nodename=None, nodedesc=None, **kwargs):
     # check if node is a valid KKR parameters node
     if not isinstance(node, Dict):
         print('Input node is not a valid Dict node')
-        raise InputValidationError('update_params needs valid parameter node as input')
+        raise InputValidationError(
+            'update_params needs valid parameter node as input')
 
     # check if add_direct is in kwargs (shortcuts checks of kkrparams by not using the kkrparams class to set the dict)
     add_direct = False
-    if 'add_direct' in list(kwargs.keys()): add_direct = kwargs.pop('add_direct')
+    if 'add_direct' in list(kwargs.keys()):
+        add_direct = kwargs.pop('add_direct')
 
-    #initialize temporary kkrparams instance containing all possible KKR parameters
+    # initialize temporary kkrparams instance containing all possible KKR parameters
     if not add_direct:
         params = kkrparams()
     else:
@@ -99,7 +102,8 @@ def update_params(node, nodename=None, nodedesc=None, **kwargs):
         for key in inp_params:
             if key not in list(params.values.keys()) and key not in _ignored_keys:
                 print('Input node contains unvalid key "{}"'.format(key))
-                raise InputValidationError('unvalid key "{}" in input parameter node'.format(key))
+                raise InputValidationError(
+                    'unvalid key "{}" in input parameter node'.format(key))
 
     # copy values from input node
     for key in inp_params:
@@ -113,7 +117,7 @@ def update_params(node, nodename=None, nodedesc=None, **kwargs):
     changed_params = {}
 
     # check if values are given as **kwargs (otherwise return input node)
-    if len(kwargs)==0:
+    if len(kwargs) == 0:
         print('No additional input keys given, return input node')
         return node.clone()
     else:
@@ -132,7 +136,7 @@ def update_params(node, nodename=None, nodedesc=None, **kwargs):
                     params[key] = kwargs[key]
                 changed_params[key] = kwargs[key]
 
-    if len(list(changed_params.keys()))==0:
+    if len(list(changed_params.keys())) == 0:
         print('No keys have been changed, return input node')
         return node.clone()
 
@@ -141,7 +145,6 @@ def update_params(node, nodename=None, nodedesc=None, **kwargs):
         nodename = 'updated KKR parameters'
     if nodedesc is None or type(nodedesc) is not str:
         nodedesc = 'changed parameters: {}'.format(changed_params)
-
 
     # create new node
     if not add_direct:
@@ -153,24 +156,28 @@ def update_params(node, nodename=None, nodedesc=None, **kwargs):
 
     return ParaNode
 
-#TODO implment VCA functionality
+# TODO implment VCA functionality
 # maybe one starts from a calculation closest to the VCA case and slowly
 # increase ZATOM which violates the _do_never_modify rule in KKR calculation
 # this should then create a new structure and modify the old potential accordingly
 # general rule: Nover destroy the data provenance!!!
+
+
 @calcfunction
 def prepare_VCA_structure_wf():
     pass
+
 
 def prepare_VCA_structure():
     pass
 
 
-#TODO implement 2D input helper
+# TODO implement 2D input helper
 # a helper workfunction would be nice to create the vacuum region etc. for 2D calculation
 @calcfunction
 def prepare_2Dcalc_wf():
     pass
+
 
 def prepare_2Dcalc():
     pass
@@ -203,7 +210,6 @@ def test_and_get_codenode(codenode, expected_code_type, use_exceptions=False):
     from aiida.common.exceptions import NotExistent
     from aiida.orm import Code
 
-
     try:
         if codenode is None:
             raise ValueError
@@ -215,7 +221,7 @@ def test_and_get_codenode(codenode, expected_code_type, use_exceptions=False):
         qb = QueryBuilder()
         qb.append(Code,
                   filters={'attributes.input_plugin':
-                               {'==': expected_code_type}},
+                           {'==': expected_code_type}},
                   project='*')
 
         valid_code_labels = ["{}@{}".format(c.label, c.get_computer().name)
@@ -224,7 +230,7 @@ def test_and_get_codenode(codenode, expected_code_type, use_exceptions=False):
         if valid_code_labels:
             msg = ("Pass as further parameter a valid code label.\n"
                    "Valid labels with a {} executable are:\n".format(
-                expected_code_type))
+                       expected_code_type))
             msg += "\n".join("* {}".format(l) for l in valid_code_labels)
 
             if use_exceptions:
@@ -236,7 +242,7 @@ def test_and_get_codenode(codenode, expected_code_type, use_exceptions=False):
             msg = ("Code not valid, and no valid codes for {}.\n"
                    "Configure at least one first using\n"
                    "    verdi code setup".format(
-                expected_code_type))
+                       expected_code_type))
             if use_exceptions:
                 raise ValueError(msg)
             else:
@@ -258,10 +264,9 @@ def get_inputs_kkr(code, remote, options, label='', description='', parameters=N
 
     # then reuse common inputs setter
     builder = get_inputs_common(KkrCalculation, code, remote, None, options, label,
-                               description, parameters, serial, imp_info)
+                                description, parameters, serial, imp_info)
 
     return builder
-
 
 
 def get_inputs_kkrimporter(code, remote, options, label='', description='', parameters=None, serial=False):
@@ -291,11 +296,11 @@ def get_inputs_voronoi(code, structure, options, label='', description='', param
     if structure is not None:
         # for 'normal' case starting from structure
         builder = get_inputs_common(VoronoiCalculation, code, None, structure, options, label,
-                                description, params, serial)
+                                    description, params, serial)
     else:
         # for parent_KKR feature used to increase lmax which cannot have 'structure' in inputs
         builder = get_inputs_common(VoronoiCalculation, code, None, None, options, label,
-                                description, params, serial, parent_KKR=parent_KKR)
+                                    description, params, serial, parent_KKR=parent_KKR)
 
     return builder
 
@@ -312,7 +317,7 @@ def get_inputs_kkrimp(code, options, label='', description='', parameters=None, 
 
     # then reuse common inputs setter
     builder = get_inputs_common(KkrimpCalculation, code, None, None, options, label,
-                               description, parameters, serial, imp_info, host_GF, imp_pot, kkrimp_remote, host_GF_Efshift)
+                                description, parameters, serial, imp_info, host_GF, imp_pot, kkrimp_remote, host_GF_Efshift)
 
     return builder
 
@@ -321,6 +326,7 @@ def get_inputs_common(calculation, code, remote, structure, options, label, desc
     """
     Base function common in get_inputs_* functions for different codes
     """
+    from aiida.orm import load_computer
     inputs = calculation.get_builder()
 
     if structure:
@@ -331,7 +337,9 @@ def get_inputs_common(calculation, code, remote, structure, options, label, desc
 
     if code:
         inputs.code = code
-
+        _sched = load_computer(code.computer.label).scheduler_type
+    else:
+        _sched = None
     if params:
         inputs.parameters = params
 
@@ -349,9 +357,15 @@ def get_inputs_common(calculation, code, remote, structure, options, label, desc
         inputs.metadata.label = ''
 
     if serial:
-        # overwrite settings for serial run
-        options['withmpi'] = False
-        options['resources'] = {"num_machines": 1}
+        if _sched in ["slurm", "pbspro"]:
+            # overwrite settings for serial run
+            options['withmpi'] = False
+            options['resources'] = {"num_machines": 1}
+        if _sched in ["sge"]:
+            options["withmpi"] = False
+            options["resources"] = {
+                "parallel_env": "smpslots", "tot_num_mpiprocs": 1
+            }
     else:
         # otherwise assume MPI parallelism if not given in input options
         if 'withmpi' not in list(options.keys()):
@@ -403,8 +417,10 @@ def get_parent_paranode(remote_data):
     """
     Return the input parameter of the parent calulation giving the remote_data node
     """
-    inp_calc = remote_data.get_incoming(link_label_filter='remote_folder').first().node
-    inp_para = inp_calc.get_incoming(link_label_filter='parameters').first().node
+    inp_calc = remote_data.get_incoming(
+        link_label_filter='remote_folder').first().node
+    inp_para = inp_calc.get_incoming(
+        link_label_filter='parameters').first().node
     return inp_para
 
 
@@ -440,15 +456,14 @@ def generate_inputcard_from_structure(parameters, structure, input_filename, par
     # initialize list of warnings
     warnings = []
 
-    #list of globally used constants
+    # list of globally used constants
     a_to_bohr = get_Ang2aBohr()
-
 
     # Get the connection between coordination number and element symbol
     # maybe do in a differnt way
 
     _atomic_numbers = {data['symbol']: num for num,
-                    data in PeriodicTableElements.items()}
+                       data in PeriodicTableElements.items()}
 
     # KKR wants units in bohr
     bravais = array(structure.cell)*a_to_bohr
@@ -466,13 +481,13 @@ def generate_inputcard_from_structure(parameters, structure, input_filename, par
     naez = len(sites)
     positions = []
     charges = []
-    weights = [] # for CPA
-    isitelist = [] # counter sites array for CPA
+    weights = []  # for CPA
+    isitelist = []  # counter sites array for CPA
     isite = 0
     for site in sites:
         pos = site.position
-        #TODO maybe convert to rel pos and make sure that type is right for script (array or tuple)
-        abspos = array(pos)*a_to_bohr/alat # also in units of alat
+        # TODO maybe convert to rel pos and make sure that type is right for script (array or tuple)
+        abspos = array(pos)*a_to_bohr/alat  # also in units of alat
         positions.append(abspos)
         isite += 1
         sitekind = structure.get_kind(site.kind_name)
@@ -486,9 +501,9 @@ def generate_inputcard_from_structure(parameters, structure, input_filename, par
                 zatom_tmp = _atomic_numbers[site_symbol]
             else:
                 zatom_tmp = 0.0
-            if vca_structure and ikind>0 and not isvoronoi:
+            if vca_structure and ikind > 0 and not isvoronoi:
                 # for VCA case take weighted average (only for KKR code, voronoi code uses zatom of first site for dummy calculation)
-                zatom  = zatom*wght_last + zatom_tmp*wght
+                zatom = zatom*wght_last + zatom_tmp*wght
                 # also reset weight to 1
                 wght = 1.
             else:
@@ -496,13 +511,13 @@ def generate_inputcard_from_structure(parameters, structure, input_filename, par
                 if vca_structure and isvoronoi:
                     wght = 1.
 
-            wght_last = wght # for VCA mode
+            wght_last = wght  # for VCA mode
 
             # make sure that for VCA only averaged position is written (or first for voronoi code)
-            if ( (vca_structure and ((len(sitekind.symbols)==1) or
-                                     (not isvoronoi and ikind==1) or
-                                     (isvoronoi and ikind==0)))
-                 or (not vca_structure) ):
+            if ((vca_structure and ((len(sitekind.symbols) == 1) or
+                                    (not isvoronoi and ikind == 1) or
+                                    (isvoronoi and ikind == 0)))
+                    or (not vca_structure)):
                 charges.append(zatom)
                 weights.append(wght)
                 isitelist.append(isite)
@@ -515,13 +530,12 @@ def generate_inputcard_from_structure(parameters, structure, input_filename, par
     # workaround for voronoi calculation with Zatom=83 (Bi potential not there!)
     if isvoronoi:
         from numpy import where
-        mask_replace_Bi_Pb = where(charges==83)
-        if len(mask_replace_Bi_Pb[0])>0:
+        mask_replace_Bi_Pb = where(charges == 83)
+        if len(mask_replace_Bi_Pb[0]) > 0:
             charges[mask_replace_Bi_Pb] = 82
             wmess = 'Bi potential not available, using Pb instead!!!'
             print('WARNING: '+wmess)
             warnings.append(wmess)
-
 
     ######################################
     # Prepare keywords for kkr from input structure
@@ -553,17 +567,17 @@ def generate_inputcard_from_structure(parameters, structure, input_filename, par
             warnings.append(wmess)
             input_dict['RMAX'] = input_dict['RMAX']*alat_input/alat
         if input_dict.get('GMAX') is not None:
-            wmess='rescale GMAX: {}'.format(1/(alat_input/alat))
+            wmess = 'rescale GMAX: {}'.format(1/(alat_input/alat))
             print('WARNING: '+wmess)
             warnings.append(wmess)
             input_dict['GMAX'] = input_dict['GMAX']*1/(alat_input/alat)
         if input_dict.get('RCLUSTZ') is not None:
-            wmess='rescale RCLUSTZ: {}'.format(alat_input/alat)
+            wmess = 'rescale RCLUSTZ: {}'.format(alat_input/alat)
             print('WARNING: '+wmess)
             warnings.append(wmess)
             input_dict['RCLUSTZ'] = input_dict['RCLUSTZ']*alat_input/alat
         if input_dict.get('RCLUSTXY') is not None:
-            wmess='rescale RCLUSTXY: {}'.format(alat_input/alat)
+            wmess = 'rescale RCLUSTXY: {}'.format(alat_input/alat)
             print('WARNING: '+wmess)
             warnings.append(wmess)
             input_dict['RCLUSTXY'] = input_dict['RCLUSTXY']*alat_input/alat
@@ -576,14 +590,16 @@ def generate_inputcard_from_structure(parameters, structure, input_filename, par
 
     # for KKR calculation set EMIN automatically from parent_calc (always in res.emin of voronoi and kkr) if not provided in input node
     if ('EMIN' not in list(input_dict.keys()) or input_dict['EMIN'] is None) and parent_calc is not None:
-        wmess='Overwriting EMIN with value from parent calculation {}'.format(parent_calc)
+        wmess = 'Overwriting EMIN with value from parent calculation {}'.format(
+            parent_calc)
         print('WARNING: '+wmess)
         warnings.append(wmess)
         if parent_calc.process_class == VoronoiCalculation:
             emin = parent_calc.outputs.output_parameters.get_dict().get('emin')
         else:
-            emin = parent_calc.outputs.output_parameters.get_dict().get('energy_contour_group').get('emin')
-        print('Setting emin:',emin, 'is emin None?',emin is None)
+            emin = parent_calc.outputs.output_parameters.get_dict().get(
+                'energy_contour_group').get('emin')
+        print('Setting emin:', emin, 'is emin None?', emin is None)
         params.set_value('EMIN', emin)
 
     # overwrite keywords with input parameter
@@ -594,7 +610,7 @@ def generate_inputcard_from_structure(parameters, structure, input_filename, par
     params.set_multiple_values(BRAVAIS=bravais, ALATBASIS=alat, NAEZ=naez,
                                ZATOM=charges, RBASIS=positions, CARTESIAN=True)
     # for CPA case:
-    if len(weights)>naez:
+    if len(weights) > naez:
         natyp = len(weights)
         params.set_value('NATYP', natyp)
         params.set_value('<CPA-CONC>', weights)
@@ -611,10 +627,14 @@ def generate_inputcard_from_structure(parameters, structure, input_filename, par
     rbr = params.get_value('<RBRIGHT>')
     zper_l = params.get_value('ZPERIODL')
     zper_r = params.get_value('ZPERIODR')
-    if rbl is not None: params.set_value('<RBLEFT>', array(rbl)*a_to_bohr/alat)
-    if rbr is not None: params.set_value('<RBRIGHT>', array(rbr)*a_to_bohr/alat)
-    if zper_l is not None: params.set_value('ZPERIODL', array(zper_l)*a_to_bohr/alat)
-    if zper_r is not None: params.set_value('ZPERIODR', array(zper_r)*a_to_bohr/alat)
+    if rbl is not None:
+        params.set_value('<RBLEFT>', array(rbl)*a_to_bohr/alat)
+    if rbr is not None:
+        params.set_value('<RBRIGHT>', array(rbr)*a_to_bohr/alat)
+    if zper_l is not None:
+        params.set_value('ZPERIODL', array(zper_l)*a_to_bohr/alat)
+    if zper_r is not None:
+        params.set_value('ZPERIODR', array(zper_r)*a_to_bohr/alat)
 
     # write inputfile
     params.fill_keywords_to_inputfile(output=input_filename)
@@ -655,7 +675,7 @@ def check_2Dinput_consistency(structure, parameters):
     if has2Dinfo and not inp_dict['INTERFACE'] and is2D:
         return (False, "'INTERFACE' parameter set to False but structure is 2D")
 
-    if has2Dinfo!=is2D:
+    if has2Dinfo != is2D:
         if is2D:
             return (False, "2D info given in parameters but structure is 3D\nstructure is 2D? {}\ninput has 2D info? {}\nset keys are: {}".format(is2D, has2Dinfo, set_keys))
         else:
@@ -680,9 +700,10 @@ def structure_from_params(parameters):
     from masci_tools.io.kkr_params import kkrparams
     from numpy import array
 
-    #check input
+    # check input
     if not isinstance(parameters, kkrparams):
-        raise InputValidationError('input parameters needs to be a "kkrparams" instance!')
+        raise InputValidationError(
+            'input parameters needs to be a "kkrparams" instance!')
 
     # initialize some stuff
     is_complete = True
@@ -720,14 +741,17 @@ def structure_from_params(parameters):
     struc = StructureData(cell=cell)
 
     # extract sites with positions, charges/Atom labels, weights
-    pos_all = array(parameters.get_value('<RBASIS>')) # positions in units of alat
+    # positions in units of alat
+    pos_all = array(parameters.get_value('<RBASIS>'))
     if not parameters.get_value('CARTESIAN'):
         # convert from internal to cartesian coordinates
         for isite in range(len(pos_all)):
             tmp_pos = pos_all[isite]
-            pos_all[isite] = tmp_pos[0]*cell[0]+tmp_pos[1]*cell[1]+tmp_pos[2]*cell[2] # cell already contains alat factor to convert to Ang. units
+            # cell already contains alat factor to convert to Ang. units
+            pos_all[isite] = tmp_pos[0]*cell[0] + \
+                tmp_pos[1]*cell[1]+tmp_pos[2]*cell[2]
     else:
-        pos_all = pos_all * alat * get_aBohr2Ang() # now positions are in Ang. units
+        pos_all = pos_all * alat * get_aBohr2Ang()  # now positions are in Ang. units
 
     # extract atom numbers
     zatom_all = parameters.get_value('<ZATOM>')
@@ -736,10 +760,10 @@ def structure_from_params(parameters):
         zatom_all = [zatom_all]
         pos_all = [pos_all]
 
-    #extract weights and sites for CPA calculations
-    if natyp==naez:
+    # extract weights and sites for CPA calculations
+    if natyp == naez:
         weights = [1. for i in range(natyp)]
-        sites = list(range(1,natyp+1))
+        sites = list(range(1, natyp+1))
     else:
         weights = parameters.get_value('<CPA-CONC>')
         sites = parameters.get_value('<SITE>')
@@ -748,17 +772,18 @@ def structure_from_params(parameters):
     for isite in sites:
         pos = pos_all[sites.index(isite)]
         weight = weights[sites.index(isite)]
-        if abs(zatom_all[isite-1]-int(zatom_all[isite-1]))>10**-4:
+        if abs(zatom_all[isite-1]-int(zatom_all[isite-1])) > 10**-4:
             # TODO deal with VCA (non-integer zatom)
             print('VCA not implemented yet, stopping here!')
             raise NotImplementedError('VCA functionality not implemented')
 
-        if zatom_all[isite-1]<1:
+        if zatom_all[isite-1] < 1:
             symbol = 'H'
             weight = 0.0
             struc.append_atom(position=pos, symbols='H', weights=0.0, mass=1.0)
         else:
-            symbol = PeriodicTableElements.get(zatom_all[isite-1]).get('symbol')
+            symbol = PeriodicTableElements.get(
+                zatom_all[isite-1]).get('symbol')
             struc.append_atom(position=pos, symbols=symbol, weights=weight)
 
     # set correct pbc for 2D case
@@ -768,8 +793,10 @@ def structure_from_params(parameters):
     # finally return structure
     return is_complete, struc
 
+
 @calcfunction
-def neworder_potential_wf(settings_node, parent_calc_folder, **kwargs) : #, parent_calc_folder2=None):
+# , parent_calc_folder2=None):
+def neworder_potential_wf(settings_node, parent_calc_folder, **kwargs):
     """
     Workfunction to create database structure for aiida_kkr.tools.modify_potential.neworder_potential function
     A temporary file is written in a Sandbox folder on the computer specified via
@@ -810,30 +837,36 @@ def neworder_potential_wf(settings_node, parent_calc_folder, **kwargs) : #, pare
         debug = kwargs.get('debug').value
     else:
         debug = False
-        
+
     if 'parent_calc_folder2' in list(kwargs.keys()):
-        parent_calc_folder2=kwargs.get('parent_calc_folder2', None)
+        parent_calc_folder2 = kwargs.get('parent_calc_folder2', None)
     else:
-        parent_calc_folder2=None
+        parent_calc_folder2 = None
 
     # check input consistency
     if not isinstance(settings_node, Dict):
-        raise InputValidationError('settings_node needs to be a valid aiida Dict node')
+        raise InputValidationError(
+            'settings_node needs to be a valid aiida Dict node')
     if not isinstance(parent_calc_folder, RemoteData):
-        raise InputValidationError('parent_calc_folder needs to be a valid aiida RemoteData node')
+        raise InputValidationError(
+            'parent_calc_folder needs to be a valid aiida RemoteData node')
     if parent_calc_folder2 is not None and not isinstance(parent_calc_folder2, RemoteData):
-        raise InputValidationError('parent_calc_folder2 needs to be a valid aiida RemoteData node')
+        raise InputValidationError(
+            'parent_calc_folder2 needs to be a valid aiida RemoteData node')
 
     settings_dict = settings_node.get_dict()
     pot1 = settings_dict.get('pot1', None)
     if pot1 is None:
-        raise InputValidationError('settings_node_dict needs to have key "pot1" containing the filename of the input potential')
+        raise InputValidationError(
+            'settings_node_dict needs to have key "pot1" containing the filename of the input potential')
     out_pot = settings_dict.get('out_pot', None)
     if out_pot is None:
-        raise InputValidationError('settings_node_dict needs to have key "out_pot" containing the filename of the input potential')
+        raise InputValidationError(
+            'settings_node_dict needs to have key "out_pot" containing the filename of the input potential')
     neworder = settings_dict.get('neworder', None)
     if neworder is None:
-        raise InputValidationError('settings_node_dict needs to have key "neworder" containing the list of new positions')
+        raise InputValidationError(
+            'settings_node_dict needs to have key "neworder" containing the list of new positions')
     pot2 = settings_dict.get('pot2', None)
     replace_newpos = settings_dict.get('replace_newpos', None)
     switch_spins = settings_dict.get('switch_spins', [])
@@ -842,13 +875,14 @@ def neworder_potential_wf(settings_node, parent_calc_folder, **kwargs) : #, pare
     # and construct output potential
     with SandboxFolder() as tempfolder:
         # Get abolute paths of input files from parent calc and filename
-        parent_calcs = parent_calc_folder.get_incoming(node_class=CalcJobNode).all()
+        parent_calcs = parent_calc_folder.get_incoming(
+            node_class=CalcJobNode).all()
         n_parents = len(parent_calcs)
         if n_parents != 1:
             raise UniquenessError(
-                    "Input RemoteData is child of {} "
-                    "calculation{}, while it should have a single parent"
-                    "".format(n_parents, "" if n_parents == 0 else "s"))
+                "Input RemoteData is child of {} "
+                "calculation{}, while it should have a single parent"
+                "".format(n_parents, "" if n_parents == 0 else "s"))
         else:
             parent_calc = parent_calcs[0].node
         with parent_calc.outputs.retrieved.open(pot1) as pot1_fhandle:
@@ -867,24 +901,24 @@ def neworder_potential_wf(settings_node, parent_calc_folder, **kwargs) : #, pare
                 neworder_spin.append(iatom*nspin+ispin)
             ii += 1
         neworder = neworder_spin
-        
-        
+
         # Copy optional files?
         if pot2 is not None and parent_calc_folder2 is not None:
-            parent_calcs = parent_calc_folder2.get_incoming(node_class=CalcJobNode).all()
+            parent_calcs = parent_calc_folder2.get_incoming(
+                node_class=CalcJobNode).all()
             n_parents = len(parent_calcs)
             if n_parents != 1:
                 raise UniquenessError(
-                        "Input RemoteData of parent_calc_folder2 is child of {} "
-                        "calculation{}, while it should have a single parent"
-                        "".format(n_parents, "" if n_parents == 0 else "s"))
+                    "Input RemoteData of parent_calc_folder2 is child of {} "
+                    "calculation{}, while it should have a single parent"
+                    "".format(n_parents, "" if n_parents == 0 else "s"))
             else:
                 parent_calc = parent_calcs[0].node
             if pot2 not in parent_calc.outputs.retrieved.list_object_names():
-                raise InputValidationError('neworder_potential_wf: pot2 does not exist', 
+                raise InputValidationError('neworder_potential_wf: pot2 does not exist',
                                            pot2,
                                            parent_calc.outputs.retrieved.list_object_names()
-                                          )
+                                           )
             with parent_calc.outputs.retrieved.open(pot2) as pot2_fhandle:
                 pot2_fpath = pot2_fhandle.name
         else:
@@ -899,7 +933,8 @@ def neworder_potential_wf(settings_node, parent_calc_folder, **kwargs) : #, pare
                                               replace_from_pot2=replace_newpos, debug=debug)
 
         # store output potential to SinglefileData
-        output_potential_sfd_node = SinglefileData(file=tempfolder.open(out_pot, u'rb'))
+        output_potential_sfd_node = SinglefileData(
+            file=tempfolder.open(out_pot, u'rb'))
 
         lbl = settings_dict.get('label', None)
         if lbl is not None:
@@ -908,7 +943,7 @@ def neworder_potential_wf(settings_node, parent_calc_folder, **kwargs) : #, pare
         if desc is not None:
             output_potential_sfd_node.description = desc
 
-        #TODO create shapefun sfd node accordingly
+        # TODO create shapefun sfd node accordingly
         """
         out_shape_path =
 
@@ -930,7 +965,6 @@ def neworder_potential_wf(settings_node, parent_calc_folder, **kwargs) : #, pare
         return output_potential_sfd_node
 
 
-
 def vca_check(structure, parameters):
     """
 
@@ -941,8 +975,8 @@ def vca_check(structure, parameters):
         nsites += len(sitekind.symbols)
     # VCA mode if CPAINFO = [-1,-1] first
     try:
-        if parameters.get_dict().get('CPAINFO')[0]<0:
-            params_vca_mode= True
+        if parameters.get_dict().get('CPAINFO')[0] < 0:
+            params_vca_mode = True
         else:
             params_vca_mode = False
     except:
@@ -950,7 +984,7 @@ def vca_check(structure, parameters):
     # check if structure supports VCA mode
     vca_structure = False
     if params_vca_mode:
-        if nsites>len(structure.sites):
+        if nsites > len(structure.sites):
             vca_structure = True
 
     return vca_structure
@@ -975,28 +1009,28 @@ def kick_out_corestates(potfile, potfile_out, emin):
     with open_general(potfile) as f:
         txt = f.readlines()
 
-    #get start of each potential part
+    # get start of each potential part
     istarts = [iline for iline in range(len(txt)) if 'POTENTIAL' in txt[iline]]
-    all_lines = list(range(len(txt))) # index array
+    all_lines = list(range(len(txt)))  # index array
 
     # change list of core states
     for ipot in range(len(nstates)):
-        if nstates[ipot]>0:
-            m = where(energies[ipot]>emin)
-            if len(m[0])>0:
+        if nstates[ipot] > 0:
+            m = where(energies[ipot] > emin)
+            if len(m[0]) > 0:
                 istart = istarts[ipot]
                 # change number of core states in potential
-                #print(txt[istart+6])
-                txt[istart+6] = '%i 1\n'%(nstates[ipot]-len(m[0]))
+                # print(txt[istart+6])
+                txt[istart+6] = '%i 1\n' % (nstates[ipot]-len(m[0]))
                 # now remove energy line accordingly
                 for ie_out in m[0][::-1]:
-                    m_out = where(array(all_lines)==istart+6+ie_out+1)[0][0]
+                    m_out = where(array(all_lines) == istart+6+ie_out+1)[0][0]
                     e_out = all_lines.pop(m_out)
 
     # find number of deleted lines
     num_deleted = len(txt)-len(all_lines)
 
-    if num_deleted>0:
+    if num_deleted > 0:
         # write output potential
         with open_general(potfile_out, u'w') as f2:
             txt_new = []
@@ -1022,17 +1056,19 @@ def kick_out_corestates_wf(potential_sfd, emin):
     with SandboxFolder() as tmpdir:
         with tmpdir.open('potential_deleted_core_states', 'w') as potfile_out:
             with potential_sfd.open(potential_sfd.filename) as potfile_in:
-                num_deleted = kick_out_corestates(potfile_in, potfile_out, emin)
+                num_deleted = kick_out_corestates(
+                    potfile_in, potfile_out, emin)
         # store new potential as single file data object
-        if num_deleted>0:
+        if num_deleted > 0:
             with tmpdir.open('potential_deleted_core_states', 'rb') as potfile_out:
                 potential_nocore_sfd = SinglefileData(file=potfile_out)
 
     # return potential
-    if num_deleted>0:
+    if num_deleted > 0:
         return potential_nocore_sfd
     else:
         return potential_sfd.clone()
+
 
 def find_cluster_radius(structure, nclsmin, n_max_box=50, nbins=100):
     """
@@ -1076,9 +1112,12 @@ def find_cluster_radius(structure, nclsmin, n_max_box=50, nbins=100):
     for site in pos:
         tmpdiff = np.sort(np.sqrt(np.sum((all_pos_box-site)**2, axis=1)))[1:]
         rmax = tmpdiff.max()
-        clssizes = [len(tmpdiff[tmpdiff<i*rmax]) for i in np.linspace(0, 1, nbins)]
-        rclsmax_atom = (np.linspace(0,1,nbins)*rmax)[np.where(np.array(clssizes)<nclsmin)[0].max()+1]
-        if rclsmax_atom>rclsmax_ang: rclsmax_ang = rclsmax_atom
+        clssizes = [len(tmpdiff[tmpdiff < i*rmax])
+                    for i in np.linspace(0, 1, nbins)]
+        rclsmax_atom = (np.linspace(0, 1, nbins) *
+                        rmax)[np.where(np.array(clssizes) < nclsmin)[0].max()+1]
+        if rclsmax_atom > rclsmax_ang:
+            rclsmax_ang = rclsmax_atom
 
     # convert also to alat units
     rclsmax_alat = rclsmax_ang/get_alat_from_bravais(cell, structure.pbc[2])

--- a/aiida_kkr/workflows/dos.py
+++ b/aiida_kkr/workflows/dos.py
@@ -42,10 +42,10 @@ class kkr_dos_wc(WorkChain):
     """
 
     _workflowversion = __version__
-    _wf_label = 'kkr_dos_wc'
-    _wf_description = 'Workflow for a KKR dos calculation starting either from a structure with automatic voronoi calculation or a valid RemoteData node of a previous calculation.'
+    _wf_label = "kkr_dos_wc"
+    _wf_description = "Workflow for a KKR dos calculation starting either from a structure with automatic voronoi calculation or a valid RemoteData node of a previous calculation."
     _wf_default = {
-        'dos_params': {
+        "dos_params": {
             "nepts": 61,              # DOS params: number of points in contour
             "tempr": 200,  # K        # DOS params: temperature
             "emin": -1,    # Ry       # DOS params: start of energy contour
@@ -53,13 +53,13 @@ class kkr_dos_wc(WorkChain):
             "kmesh": [30, 30, 30]}    # DOS params: kmesh for DOS calculation (typically higher than in scf contour)
     }
     _options_default = {
-        'queue_name': '',                        # Queue name to submit jobs too
+        "queue_name": "",                        # Queue name to submit jobs to
         # resources to allowcate for the job
-        'resources': {"num_machines": 1},
+        "resources": {"num_machines": 1},
         # walltime after which the job gets killed (gets parsed to KKR)
-        'max_wallclock_seconds': 60*60,
-        'withmpi': True,                         # execute KKR with mpi or without
-        'custom_scheduler_commands': '',         # some additional scheduler commands
+        "max_wallclock_seconds": 60*60,
+        "withmpi": True,                         # execute KKR with mpi or without
+        "custom_scheduler_commands": "",         # some additional scheduler commands
     }
 
     # intended to guide user interactively in setting up a valid wf_params node
@@ -70,7 +70,7 @@ class kkr_dos_wc(WorkChain):
         returns _wf_defaults
         """
         if not silent:
-            print('Version of workflow: {}'.format(self._workflowversion))
+            print("Version of workflow: {}".format(self._workflowversion))
         return self._wf_default
 
     @classmethod
@@ -109,25 +109,25 @@ class kkr_dos_wc(WorkChain):
         )
 
         # definition of exit code in case something goes wrong in this workflow
-        spec.exit_code(161, 'ERROR_NO_INPUT_REMOTE_DATA',
-                       'No remote_data was provided as Input')
-        spec.exit_code(162, 'ERROR_KKRCODE_NOT_CORRECT',
-                       'The code you provided for kkr does not use the plugin kkr.kkr')
-        spec.exit_code(163, 'ERROR_CALC_PARAMETERS_INVALID',
-                       'calc_parameters given are not consistent! Hint: did you give an unknown keyword?')
-        spec.exit_code(164, 'ERROR_CALC_PARAMETERS_INCOMPLETE',
-                       'calc_parameters not complete')
-        spec.exit_code(165, 'ERROR_DOS_PARAMS_INVALID',
-                       'dos_params given in wf_params are not valid')
-        spec.exit_code(166, 'ERROR_DOS_CALC_FAILED',
-                       'KKR dos calculation failed')
+        spec.exit_code(161, "ERROR_NO_INPUT_REMOTE_DATA",
+                       "No remote_data was provided as Input")
+        spec.exit_code(162, "ERROR_KKRCODE_NOT_CORRECT",
+                       "The code you provided for kkr does not use the plugin kkr.kkr")
+        spec.exit_code(163, "ERROR_CALC_PARAMETERS_INVALID",
+                       "calc_parameters given are not consistent! Hint: did you give an unknown keyword?")
+        spec.exit_code(164, "ERROR_CALC_PARAMETERS_INCOMPLETE",
+                       "calc_parameters not complete")
+        spec.exit_code(165, "ERROR_DOS_PARAMS_INVALID",
+                       "dos_params given in wf_params are not valid")
+        spec.exit_code(166, "ERROR_DOS_CALC_FAILED",
+                       "KKR dos calculation failed")
 
     def start(self):
         """
         init context and some parameters
         """
-        self.report('INFO: started KKR dos workflow version {}'
-                    ''.format(self._workflowversion))
+        self.report("INFO: started KKR dos workflow version {}"
+                    "".format(self._workflowversion))
 
         ####### init    #######
 
@@ -138,48 +138,63 @@ class kkr_dos_wc(WorkChain):
         # TODO: check for completeness
         if wf_dict == {}:
             wf_dict = self._wf_default
-            self.report('INFO: using default wf parameter')
+            self.report("INFO: using default wf parameter")
         if options_dict == {}:
             options_dict = self._options_default
-            self.report('INFO: using default options')
+            self.report("INFO: using default options")
 
         # set values, or defaults
         self.ctx.withmpi = options_dict.get(
-            'withmpi', self._options_default['withmpi'])
+            "withmpi", self._options_default["withmpi"]
+        )
         self.ctx.resources = options_dict.get(
-            'resources', self._options_default['resources'])
+            "resources", self._options_default["resources"]
+        )
         self.ctx.max_wallclock_seconds = options_dict.get(
-            'max_wallclock_seconds', self._options_default['max_wallclock_seconds'])
+            "max_wallclock_seconds",
+            self._options_default["max_wallclock_seconds"]
+        )
         self.ctx.queue = options_dict.get(
-            'queue_name', self._options_default['queue_name'])
+            "queue_name", self._options_default["queue_name"]
+        )
         self.ctx.custom_scheduler_commands = options_dict.get(
-            'custom_scheduler_commands', self._options_default['custom_scheduler_commands'])
+            "custom_scheduler_commands",
+            self._options_default["custom_scheduler_commands"]
+        )
 
         self.ctx.dos_params_dict = wf_dict.get(
-            'dos_params', self._wf_default['dos_params'])
+            "dos_params", self._wf_default["dos_params"]
+        )
         self.ctx.dos_kkrparams = None  # is set in set_params_dos
 
         self.ctx.description_wf = self.inputs.get(
-            'description', self._wf_description)
-        self.ctx.label_wf = self.inputs.get('label', self._wf_label)
+            "description", self._wf_description
+        )
+        self.ctx.label_wf = self.inputs.get("label", self._wf_label)
 
-        self.report('INFO: use the following parameter:\n'
-                    'withmpi: {}\n'
-                    'Resources: {}\n'
-                    'Walltime (s): {}\n'
-                    'queue name: {}\n'
-                    'scheduler command: {}\n'
-                    'description: {}\n'
-                    'label: {}\n'
-                    'dos_params: {}\n'.format(self.ctx.withmpi, self.ctx.resources, self.ctx.max_wallclock_seconds,
-                                              self.ctx.queue, self.ctx.custom_scheduler_commands,
-                                              self.ctx.description_wf, self.ctx.label_wf,
-                                              self.ctx.dos_params_dict))
+        self.report(
+            "INFO: use the following parameter:\n"
+            "withmpi: {}\n"
+            "Resources: {}\n"
+            "Walltime (s): {}\n"
+            "queue name: {}\n"
+            "scheduler command: {}\n"
+            "description: {}\n"
+            "label: {}\n"
+            "dos_params: {}\n"
+            .format(
+                self.ctx.withmpi, self.ctx.resources,
+                self.ctx.max_wallclock_seconds,
+                self.ctx.queue, self.ctx.custom_scheduler_commands,
+                self.ctx.description_wf, self.ctx.label_wf,
+                self.ctx.dos_params_dict
+            )
+        )
 
         # return para/vars
         self.ctx.successful = True
         self.ctx.errors = []
-        self.ctx.formula = ''
+        self.ctx.formula = ""
 
     def validate_input(self):
         """
@@ -188,13 +203,14 @@ class kkr_dos_wc(WorkChain):
         """
         inputs = self.inputs
 
-        if 'remote_data' in inputs:
+        if "remote_data" in inputs:
             input_ok = True
         else:
             input_ok = False
             return self.exit_codes.ERROR_NO_INPUT_REMOTE_DATA
 
-        # extract correct remote folder of last calculation if input remote_folder node is not from KkrCalculation but kkr_scf_wc workflow
+        # extract correct remote folder of last calculation if input
+        # remote_folder node is not from KkrCalculation but kkr_scf_wc workflow
         input_remote = self.inputs.remote_data
         # check if input_remote has single KkrCalculation parent
         parents = input_remote.get_incoming(node_class=CalcJobNode)
@@ -207,19 +223,22 @@ class kkr_dos_wc(WorkChain):
                     "Input remote_data node neither output of a KKR/voronoi calculation nor of kkr_scf_wc workflow")
             parent_workflow_out = parent_workflow.outputs.output_kkr_scf_wc_ParameterResults
             uuid_last_calc = parent_workflow_out.get_dict().get(
-                'last_calc_nodeinfo').get('uuid')
+                "last_calc_nodeinfo").get("uuid")
             last_calc = load_node(uuid_last_calc)
-            if not isinstance(last_calc, KkrCalculation) and not isinstance(last_calc, VoronoiCalculation):
+            if (
+                not isinstance(last_calc, KkrCalculation)
+                and not isinstance(last_calc, VoronoiCalculation)
+            ):
                 raise InputValidationError(
                     "Extracted last_calc node not of type KkrCalculation: check remote_data input node")
             # overwrite remote_data node with extracted remote folder
             output_remote = last_calc.outputs.remote_folder
             self.inputs.remote_data = output_remote
 
-        if 'kkr' in inputs:
+        if "kkr" in inputs:
             try:
                 test_and_get_codenode(
-                    inputs.kkr, 'kkr.kkr', use_exceptions=True)
+                    inputs.kkr, "kkr.kkr", use_exceptions=True)
             except ValueError:
                 input_ok = False
                 return self.exit_codes.ERROR_KKRCODE_NOT_CORRECT
@@ -247,8 +266,8 @@ class kkr_dos_wc(WorkChain):
             return self.exit_codes.ERROR_CALC_PARAMETERS_INVALID
 
         # step 2: check if all mandatory keys are there
-        label = ''
-        descr = ''
+        label = ""
+        descr = ""
         missing_list = para_check.get_missing_keys(use_aiida=True)
         if missing_list != []:
             kkrdefaults = kkrparams.get_KKRcalc_parameter_defaults()[0]
@@ -261,44 +280,48 @@ class kkr_dos_wc(WorkChain):
                     missing_list.remove(key_default)
             if len(missing_list) > 0:
                 self.report(
-                    'ERROR: calc_parameters misses keys: {}'.format(missing_list))
+                    "ERROR: calc_parameters misses keys: {}"
+                    .format(missing_list)
+                )
                 return self.exit_codes.ERROR_CALC_PARAMETERS_INCOMPLETE
-            self.report('updated KKR parameter node with default values: {}'.format(
-                kkrdefaults_updated))
-            label = 'add_defaults_'
-            descr = 'added missing default keys, '
+            self.report(
+                "updated KKR parameter node with default values: {}"
+                .format(kkrdefaults_updated)
+            )
+            label = "add_defaults_"
+            descr = "added missing default keys, "
 
         # overwrite energy contour to DOS contour no matter what is in input parameter node.
         # Contour parameter given as input to workflow.
         econt_new = self.ctx.dos_params_dict
         # always overwrite NPOL, N1, N3, thus add these to econt_new
-        econt_new['NPOL'] = 0
-        econt_new['NPT1'] = 0
-        econt_new['NPT3'] = 0
+        econt_new["NPOL"] = 0
+        econt_new["NPT1"] = 0
+        econt_new["NPT3"] = 0
         try:
             for key, val in econt_new.items():
-                if key == 'kmesh':
-                    key = 'BZDIVIDE'
-                elif key == 'nepts':
-                    key = 'NPT2'
+                if key == "kmesh":
+                    key = "BZDIVIDE"
+                elif key == "nepts":
+                    key = "NPT2"
                     # add IEMXD which has to be big enough
-                    print('setting IEMXD', val)
-                    para_check.set_value('IEMXD', val, silent=True)
-                elif key == 'emin':
-                    key = 'EMIN'
-                elif key == 'emax':
-                    key = 'EMAX'
-                elif key == 'tempr':
-                    key = 'TEMPR'
+                    print("setting IEMXD", val)
+                    para_check.set_value("IEMXD", val, silent=True)
+                elif key == "emin":
+                    key = "EMIN"
+                elif key == "emax":
+                    key = "EMAX"
+                elif key == "tempr":
+                    key = "TEMPR"
                 # set params
                 para_check.set_value(key, val, silent=True)
         except:
             return self.exit_codes.ERROR_DOS_PARAMS_INVALID
 
         updatenode = Dict(dict=para_check.get_dict())
-        updatenode.label = label+'KKRparam_DOS'
+        updatenode.label = label+"KKRparam_DOS"
         updatenode.description = descr + \
-            'KKR parameter node extracted from parent parameters and wf_parameter input node.'
+            "KKR parameter node extracted from parent parameters and wf_parameter input node."
 
         paranode_dos = update_params_wf(self.ctx.input_params_KKR, updatenode)
         self.ctx.dos_kkrparams = paranode_dos
@@ -308,23 +331,25 @@ class kkr_dos_wc(WorkChain):
         submit a dos calculation and interpolate result if returns complete
         """
 
-        label = 'KKR DOS calc.'
+        label = "KKR DOS calc."
         dosdict = self.ctx.dos_params_dict
-        description = 'dos calc: emin= {}, emax= {}, nepts= {}, tempr={}, kmesh={}'.format(
-            dosdict['emin'], dosdict['emax'], dosdict['nepts'], dosdict['tempr'], dosdict['kmesh'])
+        description = "dos calc: emin= {}, emax= {}, nepts= {}, tempr={}, kmesh={}".format(
+            dosdict["emin"], dosdict["emax"], dosdict["nepts"], dosdict["tempr"], dosdict["kmesh"])
         code = self.inputs.kkr
         remote = self.inputs.remote_data
         params = self.ctx.dos_kkrparams
-        options = {"max_wallclock_seconds": self.ctx.max_wallclock_seconds,
-                   "resources": self.ctx.resources,
-                   "queue_name": self.ctx.queue}  # ,
+        options = {
+            "max_wallclock_seconds": self.ctx.max_wallclock_seconds,
+            "resources": self.ctx.resources,
+            "queue_name": self.ctx.queue
+        }  # ,
         if self.ctx.custom_scheduler_commands:
             options["custom_scheduler_commands"] = self.ctx.custom_scheduler_commands
         inputs = get_inputs_kkr(code, remote, options, label, description,
                                 parameters=params, serial=(not self.ctx.withmpi))
 
         # run the DOS calculation
-        self.report('INFO: doing calculation')
+        self.report("INFO: doing calculation")
         dosrun = self.submit(KkrCalculation, **inputs)
 
         # for restart workflow:
@@ -346,46 +371,50 @@ class kkr_dos_wc(WorkChain):
         # capture error of unsuccessful DOS run
         if not self.ctx.dosrun.is_finished_ok:
             self.ctx.successful = False
-            error = ('ERROR: DOS calculation failed somehow it is '
-                     'in state {}'.format(self.ctx.dosrun.process_state))
+            error = (
+                "ERROR: DOS calculation failed somehow it is "
+                "in state {}".format(self.ctx.dosrun.process_state)
+            )
             print(error)
             from pprint import pprint
             pprint(self.ctx.dosrun.attributes)
-            print('stdout', self.ctx.dosrun.get_scheduler_stdout())
-            print('stderr', self.ctx.dosrun.get_scheduler_stderr())
+            print("stdout", self.ctx.dosrun.get_scheduler_stdout())
+            print("stderr", self.ctx.dosrun.get_scheduler_stderr())
             self.report(error)
             self.ctx.errors.append(error)
             return self.exit_codes.ERROR_DOS_CALC_FAILED
 
         # create dict to store results of workflow output
         outputnode_dict = {}
-        outputnode_dict['workflow_name'] = self.__class__.__name__
-        outputnode_dict['workflow_version'] = self._workflowversion
-        outputnode_dict['withmpi'] = self.ctx.withmpi
-        outputnode_dict['resources'] = self.ctx.resources
-        outputnode_dict['max_wallclock_seconds'] = self.ctx.max_wallclock_seconds
-        outputnode_dict['queue_name'] = self.ctx.queue
-        outputnode_dict['custom_scheduler_commands'] = self.ctx.custom_scheduler_commands
-        outputnode_dict['dos_params'] = self.ctx.dos_params_dict
+        outputnode_dict["workflow_name"] = self.__class__.__name__
+        outputnode_dict["workflow_version"] = self._workflowversion
+        outputnode_dict["withmpi"] = self.ctx.withmpi
+        outputnode_dict["resources"] = self.ctx.resources
+        outputnode_dict["max_wallclock_seconds"] = self.ctx.max_wallclock_seconds
+        outputnode_dict["queue_name"] = self.ctx.queue
+        outputnode_dict["custom_scheduler_commands"] = self.ctx.custom_scheduler_commands
+        outputnode_dict["dos_params"] = self.ctx.dos_params_dict
         try:
-            outputnode_dict['nspin'] = self.ctx.dosrun.res.nspin
+            outputnode_dict["nspin"] = self.ctx.dosrun.res.nspin
         except:
             error = "ERROR: nspin not extracted"
             self.report(error)
             self.ctx.successful = False
             self.ctx.errors.append(error)
-        outputnode_dict['successful'] = self.ctx.successful
-        outputnode_dict['list_of_errors'] = self.ctx.errors
+        outputnode_dict["successful"] = self.ctx.successful
+        outputnode_dict["list_of_errors"] = self.ctx.errors
 
         # create output node with data-provenance
         outputnode = Dict(dict=outputnode_dict)
-        outputnode.label = 'kkr_scf_wc_results'
-        outputnode.description = ''
+        outputnode.label = "kkr_scf_wc_results"
+        outputnode.description = ""
 
         self.report("INFO: create dos results nodes")
         try:
-            self.report("INFO: create dos results nodes. dos calc retrieved node={}".format(
-                self.ctx.dosrun.outputs.retrieved))
+            self.report(
+                "INFO: create dos results nodes. dos calc retrieved node={}"
+                .format(self.ctx.dosrun.outputs.retrieved)
+            )
             has_dosrun = True
         except AttributeError as e:
             self.report("ERROR: no dos calc retrieved node found")
@@ -395,19 +424,19 @@ class kkr_dos_wc(WorkChain):
         # interpol dos file and store to XyData nodes
         if has_dosrun:
             dos_retrieved = self.ctx.dosrun.outputs.retrieved
-            if 'complex.dos' in dos_retrieved.list_object_names():
+            if "complex.dos" in dos_retrieved.list_object_names():
                 dosXyDatas = parse_dosfiles(dos_retrieved)
 
         # collect output nodes with link labels
         outdict = {}
         if has_dosrun:
-            outdict['dos_data'] = dosXyDatas['dos_data']
-            outdict['dos_data_interpol'] = dosXyDatas['dos_data_interpol']
+            outdict["dos_data"] = dosXyDatas["dos_data"]
+            outdict["dos_data_interpol"] = dosXyDatas["dos_data_interpol"]
         # create data provenance of results node
         link_nodes = outdict.copy()  # link also dos output nodes
         if has_dosrun:
-            link_nodes['doscalc_remote'] = self.ctx.dosrun.outputs.remote_folder
-        outdict['results_wf'] = create_out_dict_node(outputnode, **link_nodes)
+            link_nodes["doscalc_remote"] = self.ctx.dosrun.outputs.remote_folder
+        outdict["results_wf"] = create_out_dict_node(outputnode, **link_nodes)
 
         # create links to output nodes
         for link_name, node in outdict.items():
@@ -426,7 +455,7 @@ def parse_dosfiles(dos_retrieved):
 
     eVscale = get_Ry2eV()
 
-    with dos_retrieved.open('complex.dos') as dosfolder:
+    with dos_retrieved.open("complex.dos") as dosfolder:
         ef, dos, dos_int = interpolate_dos(dosfolder, return_original=True)
 
     # convert to eV units
@@ -437,28 +466,28 @@ def parse_dosfiles(dos_retrieved):
 
     # create output nodes
     dosnode = XyData()
-    dosnode.set_x(dos[:, :, 0], 'E-EF', 'eV')
-    name = ['tot', 's', 'p', 'd', 'f', 'g']
-    name = name[:len(dos[0, 0, 1:])-1]+['ns']
+    dosnode.set_x(dos[:, :, 0], "E-EF", "eV")
+    name = ["tot", "s", "p", "d", "f", "g"]
+    name = name[:len(dos[0, 0, 1:])-1]+["ns"]
     ylists = [[], [], []]
-    for l in range(len(name)):
-        ylists[0].append(dos[:, :, 1+l])
-        ylists[1].append('dos '+name[l])
-        ylists[2].append('states/eV')
+    for line, _name in enumerate(name):
+        ylists[0].append(dos[:, :, 1+line])
+        ylists[1].append("dos {}".format(_name))
+        ylists[2].append("states/eV")
     dosnode.set_y(ylists[0], ylists[1], ylists[2])
-    dosnode.label = 'dos_data'
-    dosnode.description = 'Array data containing uniterpolated DOS (i.e. dos at finite imaginary part of energy). 3D array with (atoms, energy point, l-channel) dimensions.'
+    dosnode.label = "dos_data"
+    dosnode.description = "Array data containing uniterpolated DOS (i.e. dos at finite imaginary part of energy). 3D array with (atoms, energy point, l-channel) dimensions."
 
     # now create XyData node for interpolated data
     dosnode2 = XyData()
-    dosnode2.set_x(dos_int[:, :, 0], 'E-EF', 'eV')
+    dosnode2.set_x(dos_int[:, :, 0], "E-EF", "eV")
     ylists = [[], [], []]
-    for l in range(len(name)):
-        ylists[0].append(dos_int[:, :, 1+l])
-        ylists[1].append('interpolated dos '+name[l])
-        ylists[2].append('states/eV')
+    for line, _name in enumerate(name):
+        ylists[0].append(dos_int[:, :, 1+line])
+        ylists[1].append("interpolated dos {}".format(_name))
+        ylists[2].append("states/eV")
     dosnode2.set_y(ylists[0], ylists[1], ylists[2])
-    dosnode2.label = 'dos_interpol_data'
-    dosnode2.description = 'Array data containing interpolated DOS (i.e. dos at real axis). 3D array with (atoms, energy point, l-channel) dimensions.'
+    dosnode2.label = "dos_interpol_data"
+    dosnode2.description = "Array data containing interpolated DOS (i.e. dos at real axis). 3D array with (atoms, energy point, l-channel) dimensions."
 
-    return {'dos_data': dosnode, 'dos_data_interpol':  dosnode2}
+    return {"dos_data": dosnode, "dos_data_interpol":  dosnode2}

--- a/aiida_kkr/workflows/eos.py
+++ b/aiida_kkr/workflows/eos.py
@@ -43,24 +43,35 @@ class kkr_eos_wc(WorkChain):
     """
 
     _workflowversion = __version__
-    _wf_label = 'kkr_eos_wc_{}' # replace with structure formula
-    _wf_description = 'Equation of states workflow for {} using KKR' # replace with structure formula
+    _wf_label = 'kkr_eos_wc_{}'  # replace with structure formula
+    # replace with structure formula
+    _wf_description = 'Equation of states workflow for {} using KKR'
     # workflow options (computer settings)
-    _options_default = {'queue_name' : '',                # Queue name to submit jobs too
-                        'resources': {"num_machines": 1}, # resources to allocate for the job
-                        'max_wallclock_seconds' : 60*60,  # walltime in seconds after which the job gets killed (gets parsed to KKR)
-                        'withmpi' : True,                 # execute KKR with mpi or without
-                        'custom_scheduler_commands' : ''  # some additional scheduler commands (e.g. project numbers in job scripts, OpenMP settings, ...)
-                       }
+    _options_default = {
+        'queue_name': '',                # Queue name to submit jobs too
+        'resources': {"num_machines": 1},  # resources to allocate for the job
+        # walltime in seconds after which the job gets killed (gets parsed to KKR)
+        'max_wallclock_seconds': 60*60,
+        'withmpi': True,                 # execute KKR with mpi or without
+        # some additional scheduler commands (e.g. project numbers in job scripts, OpenMP settings, ...)
+        'custom_scheduler_commands': ''
+    }
     # workflow settings
-    _wf_default = {'scale_range' : [0.94, 1.06],    # range around volume of starting structure which eos is computed
-                   'nsteps': 7,                     # number of calculations around
-                   'ground_state_structure': True,  # create and return a structure which has the ground state volume determined by the fit used
-                   'use_primitive_structure': True, # use seekpath to get primitive structure after scaling to reduce computational time
-                   'fitfunction': 'birchmurnaghan', # fitfunction used to determine ground state volume (see ase.eos.EquationOfState class for details)
-                   'settings_kkr_startpot': kkr_startpot_wc.get_wf_defaults(silent=True), # settings for kkr_startpot behavior
-                   'settings_kkr_scf': kkr_scf_wc.get_wf_defaults(silent=True)[0]         # settings for kkr_scf behavior
-                   }
+    _wf_default = {
+        # range around volume of starting structure which eos is computed
+        'scale_range': [0.94, 1.06],
+        'nsteps': 7,                     # number of calculations around
+        # create and return a structure which has the ground state volume determined by the fit used
+        'ground_state_structure': True,
+        # use seekpath to get primitive structure after scaling to reduce computational time
+        'use_primitive_structure': True,
+        # fitfunction used to determine ground state volume (see ase.eos.EquationOfState class for details)
+        'fitfunction': 'birchmurnaghan',
+        # settings for kkr_startpot behavior
+        'settings_kkr_startpot': kkr_startpot_wc.get_wf_defaults(silent=True),
+        # settings for kkr_scf behavior
+        'settings_kkr_scf': kkr_scf_wc.get_wf_defaults(silent=True)[0]
+    }
     # change _wf_default of kkr_scf to deactivate DOS runs
     _wf_default['settings_kkr_scf']['check_dos'] = False
 
@@ -70,9 +81,9 @@ class kkr_eos_wc(WorkChain):
         Print and return _wf_defaults dictionary. Can be used to easily create set of wf_parameters.
         returns _wf_defaults, _options_default
         """
-        if not silent: print('Version of workflow: {}'.format(self._workflowversion))
+        if not silent:
+            print('Version of workflow: {}'.format(self._workflowversion))
         return self._wf_default, self._options_default
-
 
     @classmethod
     def define(cls, spec):
@@ -85,16 +96,21 @@ class kkr_eos_wc(WorkChain):
                    default=lambda: Dict(dict=cls._options_default))
         spec.input("wf_parameters", valid_type=Dict, required=False,   # workfunction settings
                    default=lambda: Dict(dict=cls._wf_default))
-        spec.input("kkr", valid_type=Code, required=True)                       # KKRhost code
-        spec.input("voronoi", valid_type=Code, required=True)                   # voronoi code
-        spec.input("structure", valid_type=StructureData, required=True)        # starting structure node
-        spec.input("calc_parameters", valid_type=Dict, required=False) # KKR input parameters (lmax etc.)
+        # KKRhost code
+        spec.input("kkr", valid_type=Code, required=True)
+        # voronoi code
+        spec.input("voronoi", valid_type=Code, required=True)
+        spec.input("structure", valid_type=StructureData,
+                   required=True)        # starting structure node
+        # KKR input parameters (lmax etc.)
+        spec.input("calc_parameters", valid_type=Dict, required=False)
 
         # define output nodes
         spec.output("eos_results", valid_type=Dict, required=True)
         spec.output("gs_structure", valid_type=StructureData, required=False)
         spec.output("explicit_kpoints", required=False)
-        spec.output("get_explicit_kpoints_path_parameters", valid_type=Dict, required=False)
+        spec.output("get_explicit_kpoints_path_parameters",
+                    valid_type=Dict, required=False)
 
         # Here the structure of the workflow is defined
         spec.outline(
@@ -116,65 +132,85 @@ class kkr_eos_wc(WorkChain):
 
         # ToDo: improve error codes
         spec.exit_code(221, 'ERROR_INVALID_INPUT',
-            message="ERROR: inputs invalid")
+                       message="ERROR: inputs invalid")
         spec.exit_code(222, 'ERROR_NOT_ENOUGH_SUCCESSFUL_CALCS',
-            message='ERROR: need at least 3 successful calculations')
+                       message='ERROR: need at least 3 successful calculations')
         spec.exit_code(223, 'ERROR_NSTEPS_TOO_SMALL',
-            message='ERROR: nsteps is smaller than 3, need at least three data points to do fitting')
+                       message='ERROR: nsteps is smaller than 3, need at least three data points to do fitting')
         spec.exit_code(224, 'ERROR_INVALID_FITFUN',
-            message='given fitfunction name not valid')
+                       message='given fitfunction name not valid')
         spec.exit_code(225, 'ERROR_VOROSTART_NOT_SUCCESSFUL',
-            message='ERROR: kkr_startpot was not successful. Check you inputs.')
-
+                       message='ERROR: kkr_startpot was not successful. Check you inputs.')
 
     def start(self):
         """
         initialize context and check input nodes
         """
 
-        self.report('INFO: starting KKR eos workflow version {}'.format(self._workflowversion))
+        self.report(
+            'INFO: starting KKR eos workflow version {}'
+            .format(self._workflowversion)
+        )
 
         # now extract information from input nodes
         try:
             self.ctx.wf_options = self.inputs.get('options').get_dict()
-            self.ctx.wf_parameters = self.inputs.get('wf_parameters').get_dict()
-            self.ctx.kkr = self.inputs.get('kkr')   #TODO: check if code is KKR code
-            self.ctx.voro = self.inputs.get('voronoi') #TODO: check if code is voronoi code
+            self.ctx.wf_parameters = self.inputs.get(
+                'wf_parameters').get_dict()
+            # TODO: check if code is KKR code
+            self.ctx.kkr = self.inputs.get('kkr')
+            # TODO: check if code is voronoi code
+            self.ctx.voro = self.inputs.get('voronoi')
             self.ctx.structure = self.inputs.get('structure')
-            self.ctx.calc_parameters = self.inputs.get('calc_parameters') # optional, TODO: needs to be filled with defaults if not present
+            # optional, TODO: needs to be filled with defaults if not present
+            self.ctx.calc_parameters = self.inputs.get('calc_parameters')
         except:
             # in case of failure, exit workflow here
             return self.exit_codes.ERROR_INVALID_INPUT
 
         # add label and description if not given (contains structure name)
-        #if self.label is None:
-        self.ctx.label = self._wf_label.format(self.ctx.structure.get_formula())
-        #if self.description is None:
-        self.ctx.description = self._wf_description.format(self.ctx.structure.get_formula())
+        # if self.label is None:
+        self.ctx.label = self._wf_label.format(
+            self.ctx.structure.get_formula())
+        # if self.description is None:
+        self.ctx.description = self._wf_description.format(
+            self.ctx.structure.get_formula())
         if self.ctx.wf_parameters['settings_kkr_startpot'].get('_label', None) is None:
-            self.ctx.wf_parameters['settings_kkr_startpot']['_label'] = self.ctx.label+'_kkr_startpot_{}'.format(self.ctx.structure.get_formula())
+            self.ctx.wf_parameters['settings_kkr_startpot']['_label'] = self.ctx.label + \
+                '_kkr_startpot_{}'.format(self.ctx.structure.get_formula())
         if self.ctx.wf_parameters['settings_kkr_startpot'].get('_description', None) is None:
-            self.ctx.wf_parameters['settings_kkr_startpot']['_description'] = self.ctx.description+' kkr_startpot step for {}'.format(self.ctx.structure.get_formula())
+            self.ctx.wf_parameters['settings_kkr_startpot']['_description'] = self.ctx.description + \
+                ' kkr_startpot step for {}'.format(
+                    self.ctx.structure.get_formula())
         if self.ctx.wf_parameters['settings_kkr_scf'].get('label', None) is None:
-            self.ctx.wf_parameters['settings_kkr_scf']['label'] = self.ctx.label+'_kkr_scf_{}'.format(self.ctx.structure.get_formula())
+            self.ctx.wf_parameters['settings_kkr_scf']['label'] = self.ctx.label + \
+                '_kkr_scf_{}'.format(self.ctx.structure.get_formula())
         if self.ctx.wf_parameters['settings_kkr_scf'].get('description', None) is None:
-            self.ctx.wf_parameters['settings_kkr_scf']['description'] = self.ctx.description+' kkr_scf step for {}'.format(self.ctx.structure.get_formula())
+            self.ctx.wf_parameters['settings_kkr_scf']['description'] = self.ctx.description + \
+                ' kkr_scf step for {}'.format(self.ctx.structure.get_formula())
 
         # initialize some other things used to collect results etc.
         self.ctx.successful = True
         self.ctx.warnings = []
-        self.ctx.rms_threshold = self.ctx.wf_parameters['settings_kkr_scf'].get('convergence_criterion', 10**-7)
+        self.ctx.rms_threshold = self.ctx.wf_parameters['settings_kkr_scf'].get(
+            'convergence_criterion', 10**-7)
         self.ctx.nsteps = self.ctx.wf_parameters.get('nsteps')
         self.ctx.scale_range = self.ctx.wf_parameters.get('scale_range')
-        self.ctx.fitfunc_gs_out = self.ctx.wf_parameters.get('fitfunction') # fitfunction used to get ground state structure
-        self.ctx.return_gs_struc = self.ctx.wf_parameters.get('ground_state_structure') # boolean, return output structure or not
-        self.ctx.use_primitive_structure = self.ctx.wf_parameters.get('use_primitive_structure')
+        self.ctx.fitfunc_gs_out = self.ctx.wf_parameters.get(
+            'fitfunction')  # fitfunction used to get ground state structure
+        self.ctx.return_gs_struc = self.ctx.wf_parameters.get(
+            'ground_state_structure')  # boolean, return output structure or not
+        self.ctx.use_primitive_structure = self.ctx.wf_parameters.get(
+            'use_primitive_structure')
         self.ctx.scaled_structures = []      # filled in prepare_strucs
-        self.ctx.fitnames = ['sj', 'taylor', 'murnaghan', 'birch', 'birchmurnaghan', 'pouriertarantola', 'vinet', 'antonschmidt', 'p3'] # list of allowed fits
-        self.ctx.sub_wf_ids = {} # filled with workflow uuids
+        self.ctx.fitnames = [
+            'sj', 'taylor', 'murnaghan', 'birch', 'birchmurnaghan',
+            'pouriertarantola', 'vinet', 'antonschmidt', 'p3'
+        ]  # list of allowed fits
+        self.ctx.sub_wf_ids = {}  # filled with workflow uuids
 
         # check input
-        if self.ctx.nsteps<3:
+        if self.ctx.nsteps < 3:
             self.exit_codes.ERROR_NSTEPS_TOO_SMALL
         if self.ctx.fitfunc_gs_out not in self.ctx.fitnames:
             self.exit_codes.ERROR_INVALID_FITFUN
@@ -182,9 +218,9 @@ class kkr_eos_wc(WorkChain):
         # set scale_factors from scale_range and nsteps
         self.ctx.scale_factors = []
         for i in range(self.ctx.nsteps):
-            scale_fac = self.ctx.scale_range[0]+i*(self.ctx.scale_range[1]-self.ctx.scale_range[0])/(self.ctx.nsteps-1)
+            scale_fac = self.ctx.scale_range[0]+i*(
+                self.ctx.scale_range[1]-self.ctx.scale_range[0])/(self.ctx.nsteps-1)
             self.ctx.scale_factors.append(scale_fac)
-
 
     def prepare_strucs(self):
         """
@@ -193,9 +229,9 @@ class kkr_eos_wc(WorkChain):
         for scale_fac in self.ctx.scale_factors:
             scaled_structure = rescale(self.ctx.structure, Float(scale_fac))
             if self.ctx.use_primitive_structure:
-                scaled_structure = get_primitive_structure(scaled_structure, Bool(False))
+                scaled_structure = get_primitive_structure(
+                    scaled_structure, Bool(False))
             self.ctx.scaled_structures.append(scaled_structure)
-
 
     def run_vorostart(self):
         """
@@ -208,21 +244,25 @@ class kkr_eos_wc(WorkChain):
             wfd[key] = self.ctx.wf_options.get(key)
             set_keys.append(key)
         # then set ef_settings
-        vorostart_settings = self.ctx.wf_parameters.get('settings_kkr_startpot')
+        vorostart_settings = self.ctx.wf_parameters.get(
+            'settings_kkr_startpot')
         for key in list(vorostart_settings.keys()):
-            if key not in set_keys: # skip setting of options (done above already)
+            # skip setting of options (done above already)
+            if key not in set_keys:
                 wfd[key] = vorostart_settings[key]
         scaled_struc = self.ctx.scaled_structures[0]
-        future = self.submit(kkr_startpot_wc, structure=scaled_struc, kkr=self.ctx.kkr,
-                             voronoi=self.ctx.voro, wf_parameters=Dict(dict=wfd),
-                             calc_parameters=self.ctx.calc_parameters,
-                             options=Dict(dict=self.ctx.wf_options))
+        future = self.submit(
+            kkr_startpot_wc, structure=scaled_struc, kkr=self.ctx.kkr,
+            voronoi=self.ctx.voro, wf_parameters=Dict(dict=wfd),
+            calc_parameters=self.ctx.calc_parameters,
+            options=Dict(dict=self.ctx.wf_options)
+        )
 
-        self.report('INFO: running kkr_startpot workflow (pk= {})'.format(future.pk))
+        self.report(
+            'INFO: running kkr_startpot workflow (pk= {})'.format(future.pk))
         self.ctx.sub_wf_ids['kkr_startpot_1'] = future.uuid
 
         return ToContext(kkr_startpot=future)
-
 
     def check_voro_out(self):
         """
@@ -246,7 +286,9 @@ class kkr_eos_wc(WorkChain):
             for rad_iatom in radii:
                 if 'rmt0' in list(rad_iatom.keys()):
                     rmt.append(rad_iatom['rmt0'])
-            rmtcore_min = array(rmt) * smallest_voro_results.get_dict().get('alat') # needs to be mutiplied by alat in atomic units!
+            # needs to be mutiplied by alat in atomic units!
+            rmtcore_min = array(
+                rmt) * smallest_voro_results.get_dict().get('alat')
             self.report('INFO: extracted rmtcore_min ({})'.format(rmtcore_min))
         else:
             return self.exit_codes.ERROR_VOROSTART_NOT_SUCCESSFUL
@@ -255,13 +297,14 @@ class kkr_eos_wc(WorkChain):
         voro_params_with_rmtcore = kkrparams(**voro_params.get_dict())
         voro_params_with_rmtcore.set_value('<RMTCORE>', rmtcore_min)
         voro_params_with_rmtcore_dict = voro_params_with_rmtcore.get_dict()
-        voro_params_with_rmtcore = update_params_wf(voro_params, Dict(dict=voro_params_with_rmtcore_dict))
-        self.report('INFO: updated kkr_parameters inlcuding RMTCORE setting (uuid={})'.format(voro_params_with_rmtcore.uuid))
+        voro_params_with_rmtcore = update_params_wf(
+            voro_params, Dict(dict=voro_params_with_rmtcore_dict))
+        self.report('INFO: updated kkr_parameters inlcuding RMTCORE setting (uuid={})'.format(
+            voro_params_with_rmtcore.uuid))
 
         # store links to context
-        self.ctx.params_kkr_run=voro_params_with_rmtcore
-        self.ctx.smallest_voro_remote=smallest_voro_remote
-
+        self.ctx.params_kkr_run = voro_params_with_rmtcore
+        self.ctx.smallest_voro_remote = smallest_voro_remote
 
     def run_kkr_steps(self):
         """
@@ -279,14 +322,16 @@ class kkr_eos_wc(WorkChain):
         # then set ef_settings
         kkr_scf_settings = self.ctx.wf_parameters.get('settings_kkr_scf')
         for key in list(kkr_scf_settings.keys()):
-            if key not in set_keys: # skip setting of options (done above already)
+            # skip setting of options (done above already)
+            if key not in set_keys:
                 wfd[key] = kkr_scf_settings[key]
 
         # used to collect all submitted calculations
         calcs = {}
 
         # submit first calculation separately
-        self.report('submit calc for scale fac= {} on {}'.format(self.ctx.scale_factors[0], self.ctx.scaled_structures[0].get_formula()))
+        self.report('submit calc for scale fac= {} on {}'.format(
+            self.ctx.scale_factors[0], self.ctx.scaled_structures[0].get_formula()))
         future = self.submit(kkr_scf_wc, kkr=self.ctx.kkr, remote_data=self.ctx.smallest_voro_remote,
                              wf_parameters=Dict(dict=wfd), calc_parameters=self.ctx.params_kkr_run,
                              options=Dict(dict=self.ctx.wf_options))
@@ -298,7 +343,8 @@ class kkr_eos_wc(WorkChain):
         for i in range(len(self.ctx.scale_factors)-1):
             scale_fac = self.ctx.scale_factors[i+1]
             scaled_struc = self.ctx.scaled_structures[i+1]
-            self.report('submit calc for scale fac= {} on {}'.format(scale_fac, scaled_struc.get_formula()))
+            self.report('submit calc for scale fac= {} on {}'.format(
+                scale_fac, scaled_struc.get_formula()))
             future = self.submit(kkr_scf_wc, structure=scaled_struc, kkr=self.ctx.kkr, voronoi=self.ctx.voro,
                                  wf_parameters=Dict(dict=wfd), calc_parameters=self.ctx.params_kkr_run,
                                  options=Dict(dict=self.ctx.wf_options))
@@ -307,14 +353,14 @@ class kkr_eos_wc(WorkChain):
 
         # save uuids of calculations to context
         self.ctx.kkr_calc_uuids = []
-        for name in sort(list(calcs.keys())): # sorting important to have correct assignment of scaling and structure info later on
+        # sorting important to have correct assignment of scaling and structure info later on
+        for name in sort(list(calcs.keys())):
             calc = calcs[name]
             self.ctx.kkr_calc_uuids.append(calc.uuid)
 
         self.report('INFO: submitted calculations: {}'.format(calcs))
 
         return ToContext(**calcs)
-
 
     def collect_data_and_fit(self):
         """
@@ -328,19 +374,22 @@ class kkr_eos_wc(WorkChain):
             n = load_node(uuid)
             try:
                 d_result = n.outputs.output_kkr_scf_wc_ParameterResults.get_dict()
-                self.report('INFO: extracting output of calculation {}: successful={}, rms={}'.format(uuid, d_result[u'successful'], d_result[u'convergence_value']))
+                self.report('INFO: extracting output of calculation {}: successful={}, rms={}'.format(
+                    uuid, d_result[u'successful'], d_result[u'convergence_value']))
                 if d_result[u'successful']:
                     pk_last_calc = d_result['last_calc_nodeinfo']['pk']
                     n2 = load_node(pk_last_calc)
                     scale = self.ctx.scale_factors[iic]
-                    ener = n2.outputs.output_parameters.get_dict()['total_energy_Ry']
+                    ener = n2.outputs.output_parameters.get_dict()[
+                        'total_energy_Ry']
                     rms = d_result[u'convergence_value']
                     scaled_struc = self.ctx.scaled_structures[iic]
                     v = scaled_struc.get_cell_volume()
-                    if rms<=self.ctx.rms_threshold: # only take those calculations which
+                    if rms <= self.ctx.rms_threshold:  # only take those calculations which
                         etot.append([scale, ener, v, rms])
                     else:
-                        warn = 'rms of calculation with uuid={} not low enough ({} > {})'.format(uuid, rms, self.ctx.rms_threshold)
+                        warn = 'rms of calculation with uuid={} not low enough ({} > {})'.format(
+                            uuid, rms, self.ctx.rms_threshold)
                         self.report('WARNING: {}'.format(warn))
                         self.ctx.warnings.append(warn)
             except:
@@ -348,21 +397,20 @@ class kkr_eos_wc(WorkChain):
                 self.report('WARNING: {}'.format(warn))
                 self.ctx.warnings.append(warn)
 
-
         # collect calculation outcome
         etot = array(etot)
         self.report('INFO: collected data from calculations= {}'.format(etot))
 
         # check if at least 3 points were successful (otherwise fit does not work)
-        if len(etot)<3:
+        if len(etot) < 3:
             return self.exit_codes.ERROR_NOT_ENOUGH_SUCCESSFUL_CALCS
 
-        scalings = etot[:,0]
-        rms = etot[:,-1]
+        scalings = etot[:, 0]
+        rms = etot[:, -1]
         # convert to eV and per atom units
-        etot = etot/len(scaled_struc.sites) # per atom values
-        etot[:,1] = etot[:,1] * get_Ry2eV() # convert energy from Ry to eV
-        volumes, energies = etot[:,2], etot[:,1]
+        etot = etot/len(scaled_struc.sites)  # per atom values
+        etot[:, 1] = etot[:, 1] * get_Ry2eV()  # convert energy from Ry to eV
+        volumes, energies = etot[:, 2], etot[:, 1]
 
         # do multiple fits to data
         self.report('INFO: output of fits:')
@@ -377,25 +425,30 @@ class kkr_eos_wc(WorkChain):
                 v0, e0, B = eos.fit()
                 fitdata[fitfunc] = [v0, e0, B]
                 alldat.append([v0, e0, B])
-                self.report('{:16} {:8.3f} {:7.3f} {:7.3f}'.format(fitfunc, v0, e0, B))
-            except: # capture all errors and mark fit as unsuccessful
-               self.ctx.warnings.append('fit unsuccessful for {} function'.format(fitfunc))
-               if fitfunc == self.ctx.fitfunc_gs_out:
-                   self.ctx.successful = False
+                self.report('{:16} {:8.3f} {:7.3f} {:7.3f}'.format(
+                    fitfunc, v0, e0, B))
+            except:  # capture all errors and mark fit as unsuccessful
+                self.ctx.warnings.append(
+                    'fit unsuccessful for {} function'.format(fitfunc))
+                if fitfunc == self.ctx.fitfunc_gs_out:
+                    self.ctx.successful = False
         alldat = array(alldat)
         self.report('-----------------------------------------')
-        self.report('{:16} {:8.3f} {:7.3f} {:7.3f}'.format('mean', mean(alldat[:,0]), mean(alldat[:,1]), mean(alldat[:,2])))
-        self.report('{:16} {:8.3f} {:7.3f} {:7.3f}'.format('std', std(alldat[:,0]), std(alldat[:,1]), std(alldat[:,2])))
+        self.report('{:16} {:8.3f} {:7.3f} {:7.3f}'.format(
+            'mean', mean(alldat[:, 0]), mean(alldat[:, 1]), mean(alldat[:, 2])))
+        self.report('{:16} {:8.3f} {:7.3f} {:7.3f}'.format(
+            'std', std(alldat[:, 0]), std(alldat[:, 1]), std(alldat[:, 2])))
 
         # store results in context
-        self.ctx.volumes=volumes
-        self.ctx.energies=energies
-        self.ctx.scalings=scalings
+        self.ctx.volumes = volumes
+        self.ctx.energies = energies
+        self.ctx.scalings = scalings
         self.ctx.rms = rms
-        self.ctx.fitdata=fitdata
-        self.ctx.fit_mean_values={'<v0>':mean(alldat[:,0]), '<e0>':mean(alldat[:,1]), '<B>':mean(alldat[:,2])}
-        self.ctx.fit_std_values={'s_v0':std(alldat[:,0]), 's_e0':std(alldat[:,1]), 's_B':std(alldat[:,2])}
-
+        self.ctx.fitdata = fitdata
+        self.ctx.fit_mean_values = {'<v0>': mean(alldat[:, 0]), '<e0>': mean(
+            alldat[:, 1]), '<B>': mean(alldat[:, 2])}
+        self.ctx.fit_std_values = {'s_v0': std(alldat[:, 0]), 's_e0': std(
+            alldat[:, 1]), 's_B': std(alldat[:, 2])}
 
     def return_results(self):
         """
@@ -427,10 +480,13 @@ class kkr_eos_wc(WorkChain):
             gs_structure = rescale(self.ctx.structure, Float(scale_fac0))
             if self.ctx.use_primitive_structure:
                 tmpdict = get_primitive_structure(gs_structure, Bool(True))
-                conv_structure, explicit_kpoints, parameters, gs_structure = tmpdict['conv_structure'], tmpdict['explicit_kpoints'], tmpdict['parameters'], tmpdict['primitive_structure']
+                conv_structure, explicit_kpoints, parameters, gs_structure = tmpdict['conv_structure'], tmpdict[
+                    'explicit_kpoints'], tmpdict['parameters'], tmpdict['primitive_structure']
                 outdict['gs_kpoints_seekpath_params_uuid'] = parameters.uuid
-            gs_structure.label = 'ground_state_structure_{}'.format(gs_structure.get_formula())
-            gs_structure.description = 'Ground state structure of {} after running eos workflow. Uses {} fit.'.format(gs_structure.get_formula(), self.ctx.fitfunc_gs_out)
+            gs_structure.label = 'ground_state_structure_{}'.format(
+                gs_structure.get_formula())
+            gs_structure.description = 'Ground state structure of {} after running eos workflow. Uses {} fit.'.format(
+                gs_structure.get_formula(), self.ctx.fitfunc_gs_out)
             outdict['gs_structure_uuid'] = gs_structure.uuid
 
         # create output nodes in dict with link names
@@ -443,13 +499,16 @@ class kkr_eos_wc(WorkChain):
 
         # create results node with calcfunction for data provenance
         link_nodes = outnodes.copy()
-        for wf_label,sub_wf_uuid in self.ctx.sub_wf_ids.items():
+        for wf_label, sub_wf_uuid in self.ctx.sub_wf_ids.items():
             if 'kkr_scf' in wf_label:
-                link_nodes[wf_label] = load_node(sub_wf_uuid).outputs.output_kkr_scf_wc_ParameterResults
+                link_nodes[wf_label] = load_node(
+                    sub_wf_uuid).outputs.output_kkr_scf_wc_ParameterResults
             else:
-                link_nodes[wf_label] = load_node(sub_wf_uuid).outputs.results_vorostart_wc
-        outnodes['eos_results'] = create_out_dict_node(Dict(dict=outdict), **link_nodes)
-        
+                link_nodes[wf_label] = load_node(
+                    sub_wf_uuid).outputs.results_vorostart_wc
+        outnodes['eos_results'] = create_out_dict_node(
+            Dict(dict=outdict), **link_nodes)
+
         # set out nodes and corresponding link names
         for link_name, node in outnodes.items():
             self.out(link_name, node)
@@ -476,6 +535,7 @@ def rescale_no_wf(structure, scale):
     rescaled_structure = StructureData(ase=new_ase)
 
     return rescaled_structure
+
 
 @calcfunction
 def rescale(inp_structure, scale):
@@ -507,6 +567,6 @@ def get_primitive_structure(structure, return_all):
     parameters = output['parameters']
     primitive_structure = output['primitive_structure']
     if return_all:
-        return {'conv_structure':conv_structure, 'explicit_kpoints':explicit_kpoints, 'parameters':parameters, 'primitive_structure':primitive_structure}
+        return {'conv_structure': conv_structure, 'explicit_kpoints': explicit_kpoints, 'parameters': parameters, 'primitive_structure': primitive_structure}
     else:
         return primitive_structure

--- a/aiida_kkr/workflows/kkr_scf.py
+++ b/aiida_kkr/workflows/kkr_scf.py
@@ -27,16 +27,16 @@ __license__ = "MIT license, see LICENSE.txt file"
 __version__ = "0.10.4"
 __contributors__ = (u"Jens Broeder", u"Philipp Rüßmann")
 
-#TODO: magnetism (init and converge magnetic state)
-#TODO: check convergence (RMAX, GMAX etc.)
-#TODO: save timing info of the steps
-#TODO: switch to LLOYD
-#TODO: emin-emax setting
-#TODO: restart from workflow output instead of calculation output
-#TODO: add warnings
-#TODO: maybe define the energy point density instead of a fixed number as in input?
-#TODO: overwrite defaults from parent if parent is previous kkr_scf run
-#TODO: retrieve DOS within scf run
+# TODO: magnetism (init and converge magnetic state)
+# TODO: check convergence (RMAX, GMAX etc.)
+# TODO: save timing info of the steps
+# TODO: switch to LLOYD
+# TODO: emin-emax setting
+# TODO: restart from workflow output instead of calculation output
+# TODO: add warnings
+# TODO: maybe define the energy point density instead of a fixed number as in input?
+# TODO: overwrite defaults from parent if parent is previous kkr_scf run
+# TODO: retrieve DOS within scf run
 
 
 class kkr_scf_wc(WorkChain):
@@ -50,11 +50,11 @@ class kkr_scf_wc(WorkChain):
     optional with calc_parameters
     (2) Start from an existing Voronoi or KKR calculation, with a remoteData
 
-    :param wf_parameters: (Dict), Workchain Spezifications
+    :param wf_parameters: (Dict), Workchain Specifications
     :param options: (Dict); specifications for the computer
     :param structure: (StructureData), Crystal structure
-    :param calc_parameters: (Dict), Vornoi/Kkr Parameters
-    :param remote_data: (RemoteData), from a KKR, or Vornoi calculation
+    :param calc_parameters: (Dict), Voronoi/Kkr Parameters
+    :param remote_data: (RemoteData), from a KKR, or Voronoi calculation
     :param voronoi: (Code)
     :param kkr: (Code)
 
@@ -76,58 +76,72 @@ class kkr_scf_wc(WorkChain):
     1. This workflow does not work with local codes!
     """
 
-
     _workflowversion = __version__
-    _wf_default = {'kkr_runmax': 5,                           # Maximum number of kkr jobs/starts (defauld iterations per start)
-                   'convergence_criterion' : 10**-8,          # Stop if charge denisty is converged below this value
-                   'mixreduce': 0.5,                          # reduce mixing factor by this factor if calculaito fails due to too large mixing
-                   'threshold_aggressive_mixing': 8*10**-3,   # threshold after which agressive mixing is used
-                   'strmix': 0.03,                            # mixing factor of simple mixing
-                   'brymix': 0.05,                            # mixing factor of aggressive mixing
-                   'nsteps': 50,                              # number of iterations done per KKR calculation
-                   'convergence_setting_coarse': {            # setting of the coarse preconvergence
-                        'npol': 7,
-                        'n1': 3,
-                        'n2': 11,
-                        'n3': 3,
-                        'tempr': 1000.0,
-                        'kmesh': [10, 10, 10]},
-                   'threshold_switch_high_accuracy': 10**-3,  # threshold after which final conversion settings are used
-                   'convergence_setting_fine': {              # setting of the final convergence (lower tempr, 48 epts, denser k-mesh)
-                        'npol': 5,
-                        'n1': 7,
-                        'n2': 29,
-                        'n3': 7,
-                        'tempr': 600.0,
-                        'kmesh': [30, 30, 30]},
-                   'mag_init' : False,                        # initialize and converge magnetic calculation
-                   'hfield' : 0.02, # Ry                      # external magnetic field used in initialization step
-                   'init_pos' : None,                         # position in unit cell where magnetic field is applied [default (None) means apply to all]
-                   'fix_dir_threshold': 1.0,                  # fix direction of magnetic moment if the direction changes less than this value in degrees (calculated as sqrt((delta theta)**2 + (delta phi)**2))
-                   'retreive_dos_data_scf_run' : False,       # add DOS to testopts and retrieve dos.atom files in each scf run
-                   }
-    _options_default = {'queue_name' : '',                         # Queue name to submit jobs too
-                        'resources': {"num_machines": 1},          # resources to allowcate for the job
-                        'max_wallclock_seconds' : 60*60,           # walltime after which the job gets killed (gets parsed to KKR)
-                        'withmpi' : True,                          # execute KKR with mpi or without
-                        'custom_scheduler_commands' : ''           # some additional scheduler commands
-                        }
+    _wf_default = {
+        # Maximum number of kkr jobs/starts (defauld iterations per start)
+        "kkr_runmax": 5,
+        # Stop if charge denisty is converged below this value
+        "convergence_criterion": 10**-8,
+        # reduce mixing factor by this factor if calculation fails due to too large mixing
+        "mixreduce": 0.5,
+        # threshold after which agressive mixing is used
+        "threshold_aggressive_mixing": 8*10**-3,
+        "strmix": 0.03,                            # mixing factor of simple mixing
+        "brymix": 0.05,                            # mixing factor of aggressive mixing
+        # number of iterations done per KKR calculation
+        "nsteps": 50,
+        "convergence_setting_coarse": {            # setting of the coarse preconvergence
+            "npol": 7,
+            "n1": 3,
+            "n2": 11,
+            "n3": 3,
+            "tempr": 1000.0,
+            "kmesh": [10, 10, 10]},
+        # threshold after which final conversion settings are used
+        "threshold_switch_high_accuracy": 10**-3,
+        "convergence_setting_fine": {              # setting of the final convergence (lower tempr, 48 epts, denser k-mesh)
+            "npol": 5,
+            "n1": 7,
+            "n2": 29,
+            "n3": 7,
+            "tempr": 600.0,
+            "kmesh": [30, 30, 30]},
+        # initialize and converge magnetic calculation
+        "mag_init": False,
+        # Ry                      # external magnetic field used in initialization step
+        "hfield": 0.02,
+        # position in unit cell where magnetic field is applied [default (None) means apply to all]
+        "init_pos": None,
+        # fix direction of magnetic moment if the direction changes less than this value in degrees (calculated as sqrt((delta theta)**2 + (delta phi)**2))
+        "fix_dir_threshold": 1.0,
+        # add DOS to testopts and retrieve dos.atom files in each scf run
+        "retreive_dos_data_scf_run": False,
+    }
+    _options_default = {
+        "queue_name": "",                         # Queue name to submit jobs too
+        # resources to allowcate for the job
+        "resources": {"num_machines": 1},
+        # walltime after which the job gets killed (gets parsed to KKR)
+        "max_wallclock_seconds": 60*60,
+        "withmpi": True,                          # execute KKR with mpi or without
+        "custom_scheduler_commands": ""           # some additional scheduler commands
+    }
     # set these keys from defaults in kkr_startpot workflow since they are only passed onto that workflow
     for key, value in kkr_startpot_wc.get_wf_defaults(silent=True).items():
-        if key in ['dos_params', 'fac_cls_increase', 'natom_in_cls_min', 'delta_e_min', 'threshold_dos_zero', 'check_dos']:
+        if key in ["dos_params", "fac_cls_increase", "natom_in_cls_min", "delta_e_min", "threshold_dos_zero", "check_dos"]:
             _wf_default[key] = value
 
-
     # intended to guide user interactively in setting up a valid wf_params node
+
     @classmethod
     def get_wf_defaults(self, silent=False):
         """
         Print and return _wf_default dictionary. Can be used to easily create set of wf_parameters.
         returns _wf_default, _options_default
         """
-        if not silent: print('Version of workflow: {}'.format(self._workflowversion))
+        if not silent:
+            print("Version of workflow: {}".format(self._workflowversion))
         return self._wf_default, self._options_default
-
 
     @classmethod
     def define(cls, spec):
@@ -139,56 +153,58 @@ class kkr_scf_wc(WorkChain):
         spec.input("wf_parameters", valid_type=Dict, required=False,
                    default=lambda: Dict(dict=cls._wf_default),
                    help="Settings for the workflow. Use `KkrCalculation.get_wf_defaults()` to get the default values and default options."
-                  )
+                   )
         spec.input("options", valid_type=Dict, required=False,
                    default=lambda: Dict(dict=cls._wf_default),
                    help="Computer settings used by the calculations in the workflow (see also helo string of wf_parameters)."
-                  )
+                   )
         spec.input("structure", valid_type=StructureData, required=False,
                    help="""Input structure for which a calculation is started with a VoronoiCalculation.
 Can be skipped if a previous KkrCalculation is given with the `remote_data` input node."""
-                  )
+                   )
         spec.input("calc_parameters", valid_type=Dict, required=False,
                    help="KKR-specific calculation parameters (LMAX etc.), usually set up with the help of the `kkrparams` class."
-                  )
+                   )
         spec.input("remote_data", valid_type=RemoteData, required=False,
                    help="RemodeFolder node of a preconverged calculation. Can be used as a starting point to skip the Voronoi step."
-                  )
+                   )
         spec.input("voronoi", valid_type=Code, required=False,
                    help="Voronoi code node, needed only if `strucure` input node is given."
-                  )
+                   )
         spec.input("kkr", valid_type=Code, required=True,
                    help="KKRhost code node which will run the KkrCalculations"
-                  )
+                   )
         spec.input("startpot_overwrite", valid_type=SinglefileData, required=False,
                    help="""Potential SinglefileData, can be used to overwrite the starting potential from Voronoi
  (the shapefun will be used though and thus needs to be compatible).
  This can be used to construct a better starting potential from a preconverged calculation (e.g. in a smaller unit cell)."""
-                  )
-        spec.input('initial_noco_angles', valid_type=Dict, required=False,
+                   )
+        spec.input("initial_noco_angles", valid_type=Dict, required=False,
                    help="Initial non-collinear angles for the magnetic moments of the impurities. See KkrCalculation for details."
-                  )
+                   )
 
         # define output nodes
-        spec.output("output_kkr_scf_wc_ParameterResults", valid_type=Dict, required=True)
+        spec.output("output_kkr_scf_wc_ParameterResults",
+                    valid_type=Dict, required=True)
         spec.output("last_calc_out", valid_type=Dict, required=False)
         spec.output("last_RemoteData", valid_type=RemoteData, required=False)
         spec.output("last_InputParameters", valid_type=Dict, required=False)
         spec.output("results_vorostart", valid_type=Dict, required=False)
-        spec.output("starting_dosdata_interpol", valid_type=XyData, required=False)
-        spec.output("final_dosdata_interpol", valid_type=XyData, required=False)
+        spec.output("starting_dosdata_interpol",
+                    valid_type=XyData, required=False)
+        spec.output("final_dosdata_interpol",
+                    valid_type=XyData, required=False)
         spec.output("last_noco_angles", valid_type=Dict, required=False)
-
 
         # Here the structure of the workflow is defined
         spec.outline(
             cls.start,
             # check if voronoi run needed, otherwise skip this step
             if_(cls.validate_input)(
-                    # run kkr_startpot workflow (sets up voronoi input, runs voro calc, does some consistency checks)
-                    cls.run_voronoi,
-                    # check output of run_voronoi and determine if calculation has to be terminated here
-                    cls.check_voronoi),
+                # run kkr_startpot workflow (sets up voronoi input, runs voro calc, does some consistency checks)
+                cls.run_voronoi,
+                # check output of run_voronoi and determine if calculation has to be terminated here
+                cls.check_voronoi),
             # while loop for KKR run(s), first simple mixing
             # then Anderson with corase pre-convergence settings
             # finally convergence step with higher accuracy
@@ -209,44 +225,43 @@ Can be skipped if a previous KkrCalculation is given with the `remote_data` inpu
         )
 
         # definition of exit codes if the workflow needs to be terminated
-        spec.exit_code(221, 'ERROR_NO_PARENT_PARAMS_FOUND',
-          message='Unable to extract parent paremeter node of input remote folder')
-        spec.exit_code(222, 'ERROR_INVALID_KKR_CODE',
-          message='The code you provided for kkr does not use the plugin kkr.kkr')
-        spec.exit_code(223, 'ERROR_INVALID_VORONOI_CODE',
-          message='The code you provided for voronoi does not use the plugin kkr.voro')
-        spec.exit_code(224, 'ERROR_NO_VORONOI_CODE_GIVEN',
-          message='ERROR: StructureData was provided, but no voronoi code was provided')
-        spec.exit_code(225, 'ERROR_NOT_ENOUGH_INPUTS',
-          message='ERROR: No StructureData nor remote_data was provided as Input')
-        spec.exit_code(226, 'ERROR_KKR_STARTPOT_FAILED',
-          message='ERROR: kkr_startpot_wc step failed!')
-        spec.exit_code(227, 'ERROR_DOS_RUN_UNSUCCESFUL',
-          message='DOS run unsuccessful. Check inputs.')
-        spec.exit_code(228, 'ERROR_CALC_PARAMETERS_INCOMPLETE',
-          message='ERROR: calc_parameters given are not consistent! Missing mandatory keys')
-        spec.exit_code(229, 'ERROR_CALC_PARAMTERS_INCONSISTENT',
-          message='ERROR: calc_parameters given are not consistent! Hint: did you give an unknown keyword?')
-        spec.exit_code(230, 'ERROR_NO_CALC_PARAMETERS_GIVEN',
-          message='ERROR: calc_parameters not given as input but are needed!')
-        spec.exit_code(231, 'ERROR_PARAM_UPDATE_FAILED',
-          message='ERROR: parameter update unsuccessful: some key, value pair not valid!')
-        spec.exit_code(232, 'ERROR_CALC_PARAMTERS_INCOMPLETE',
-          message='ERROR: calc_parameters misses keys')
-        spec.exit_code(233, 'ERROR_LAST_REMOTE_NOT_FOUND',
-          message='ERROR: last_remote could not be set to a previous succesful calculation')
-        spec.exit_code(234, 'ERROR_MAX_KKR_RESTARTS_REACHED',
-          message='ERROR: maximal number of KKR restarts reached. Exiting now!')
-        spec.exit_code(235, 'ERROR_CALC_SUBMISSION_FAILED',
-          message='ERROR: last KKRcalc in SUBMISSIONFAILED state')
-
+        spec.exit_code(221, "ERROR_NO_PARENT_PARAMS_FOUND",
+                       message="Unable to extract parent paremeter node of input remote folder")
+        spec.exit_code(222, "ERROR_INVALID_KKR_CODE",
+                       message="The code you provided for kkr does not use the plugin kkr.kkr")
+        spec.exit_code(223, "ERROR_INVALID_VORONOI_CODE",
+                       message="The code you provided for voronoi does not use the plugin kkr.voro")
+        spec.exit_code(224, "ERROR_NO_VORONOI_CODE_GIVEN",
+                       message="ERROR: StructureData was provided, but no voronoi code was provided")
+        spec.exit_code(225, "ERROR_NOT_ENOUGH_INPUTS",
+                       message="ERROR: No StructureData nor remote_data was provided as Input")
+        spec.exit_code(226, "ERROR_KKR_STARTPOT_FAILED",
+                       message="ERROR: kkr_startpot_wc step failed!")
+        spec.exit_code(227, "ERROR_DOS_RUN_UNSUCCESSFUL",
+                       message="DOS run unsuccessful. Check inputs.")
+        spec.exit_code(228, "ERROR_CALC_PARAMETERS_INCOMPLETE",
+                       message="ERROR: calc_parameters given are not consistent! Missing mandatory keys")
+        spec.exit_code(229, "ERROR_CALC_PARAMTERS_INCONSISTENT",
+                       message="ERROR: calc_parameters given are not consistent! Hint: did you give an unknown keyword?")
+        spec.exit_code(230, "ERROR_NO_CALC_PARAMETERS_GIVEN",
+                       message="ERROR: calc_parameters not given as input but are needed!")
+        spec.exit_code(231, "ERROR_PARAM_UPDATE_FAILED",
+                       message="ERROR: parameter update unsuccessful: some key, value pair not valid!")
+        spec.exit_code(232, "ERROR_CALC_PARAMTERS_INCOMPLETE",
+                       message="ERROR: calc_parameters misses keys")
+        spec.exit_code(233, "ERROR_LAST_REMOTE_NOT_FOUND",
+                       message="ERROR: last_remote could not be set to a previous successful calculation")
+        spec.exit_code(234, "ERROR_MAX_KKR_RESTARTS_REACHED",
+                       message="ERROR: maximal number of KKR restarts reached. Exiting now!")
+        spec.exit_code(235, "ERROR_CALC_SUBMISSION_FAILED",
+                       message="ERROR: last KKRcalc in SUBMISSIONFAILED state")
 
     def start(self):
         """
         init context and some parameters
         """
-        self.report('INFO: started KKR convergence workflow version {}'
-                    ''.format(self._workflowversion))
+        self.report("INFO: started KKR convergence workflow version {}"
+                    "".format(self._workflowversion))
 
         ####### init #######
 
@@ -278,103 +293,128 @@ Can be skipped if a previous KkrCalculation is given with the `remote_data` inpu
 
         if wf_dict == {}:
             wf_dict = self._wf_default
-            self.report('INFO: using default wf parameter')
+            self.report("INFO: using default wf parameter")
         if options_dict == {}:
             options_dict = self._options_default
-            self.report('INFO: using default options')
+            self.report("INFO: using default options")
 
         # set values from input, or defaults
-        self.ctx.withmpi = options_dict.get('withmpi', self._options_default['withmpi'])
-        self.ctx.resources = options_dict.get('resources', self._options_default['resources'])
-        self.ctx.max_wallclock_seconds = options_dict.get('max_wallclock_seconds', self._options_default['max_wallclock_seconds'])
-        self.ctx.queue = options_dict.get('queue_name', self._options_default['queue_name'])
-        self.ctx.custom_scheduler_commands = options_dict.get('custom_scheduler_commands', self._options_default['custom_scheduler_commands'])
-        self.ctx.options_params_dict = Dict(dict={'withmpi': self.ctx.withmpi, 'resources': self.ctx.resources,
-                                                           'max_wallclock_seconds': self.ctx.max_wallclock_seconds, 'queue_name': self.ctx.queue,
-                                                           'custom_scheduler_commands': self.ctx.custom_scheduler_commands})
+        self.ctx.withmpi = options_dict.get(
+            "withmpi", self._options_default["withmpi"])
+        self.ctx.resources = options_dict.get(
+            "resources", self._options_default["resources"])
+        self.ctx.max_wallclock_seconds = options_dict.get(
+            "max_wallclock_seconds", self._options_default["max_wallclock_seconds"])
+        self.ctx.queue = options_dict.get(
+            "queue_name", self._options_default["queue_name"])
+        self.ctx.custom_scheduler_commands = options_dict.get(
+            "custom_scheduler_commands", self._options_default["custom_scheduler_commands"])
+        self.ctx.options_params_dict = Dict(
+            dict={
+                "withmpi": self.ctx.withmpi, "resources": self.ctx.resources,
+                "max_wallclock_seconds": self.ctx.max_wallclock_seconds, "queue_name": self.ctx.queue,
+                "custom_scheduler_commands": self.ctx.custom_scheduler_commands
+            }
+        )
 
         # set label and description
-        self.ctx.description_wf = self.inputs.get('description', 'Workflow for '
-                                                  'a KKR scf calculation starting '
-                                                  'either from a structure with '
-                                                  'automatic voronoi calculation '
-                                                  'or a valid RemoteData node of '
-                                                  'a previous calculation')
-        self.ctx.label_wf = self.inputs.get('label', 'kkr_scf_wc')
+        self.ctx.description_wf = self.inputs.get(
+            "description", "Workflow for "
+            "a KKR scf calculation starting "
+            "either from a structure with "
+            "automatic voronoi calculation "
+            "or a valid RemoteData node of "
+            "a previous calculation"
+        )
+        self.ctx.label_wf = self.inputs.get("label", "kkr_scf_wc")
 
         # set workflow parameters
-        self.ctx.max_number_runs = wf_dict.get('kkr_runmax', self._wf_default['kkr_runmax'])
-        self.ctx.strmix = wf_dict.get('strmix', self._wf_default['strmix'])
-        self.ctx.brymix = wf_dict.get('brymix', self._wf_default['brymix'])
-        self.ctx.check_dos = wf_dict.get('check_dos', self._wf_default['check_dos'])
-        self.ctx.dos_params = wf_dict.get('dos_params', self._wf_default['dos_params'])
-        self.ctx.convergence_criterion = wf_dict.get('convergence_criterion', self._wf_default['convergence_criterion'])
-        self.ctx.convergence_setting_coarse = wf_dict.get('convergence_setting_coarse', self._wf_default['convergence_setting_coarse'])
-        self.ctx.convergence_setting_fine = wf_dict.get('convergence_setting_fine', self._wf_default['convergence_setting_fine'])
-        self.ctx.mixreduce = wf_dict.get('mixreduce', self._wf_default['mixreduce'])
-        self.ctx.nsteps = wf_dict.get('nsteps', self._wf_default['nsteps'])
-        self.ctx.threshold_aggressive_mixing = wf_dict.get('threshold_aggressive_mixing', self._wf_default['threshold_aggressive_mixing'])
-        self.ctx.threshold_switch_high_accuracy = wf_dict.get('threshold_switch_high_accuracy', self._wf_default['threshold_switch_high_accuracy'])
+        self.ctx.max_number_runs = wf_dict.get(
+            "kkr_runmax", self._wf_default["kkr_runmax"])
+        self.ctx.strmix = wf_dict.get("strmix", self._wf_default["strmix"])
+        self.ctx.brymix = wf_dict.get("brymix", self._wf_default["brymix"])
+        self.ctx.check_dos = wf_dict.get(
+            "check_dos", self._wf_default["check_dos"])
+        self.ctx.dos_params = wf_dict.get(
+            "dos_params", self._wf_default["dos_params"])
+        self.ctx.convergence_criterion = wf_dict.get(
+            "convergence_criterion", self._wf_default["convergence_criterion"])
+        self.ctx.convergence_setting_coarse = wf_dict.get(
+            "convergence_setting_coarse", self._wf_default["convergence_setting_coarse"])
+        self.ctx.convergence_setting_fine = wf_dict.get(
+            "convergence_setting_fine", self._wf_default["convergence_setting_fine"])
+        self.ctx.mixreduce = wf_dict.get(
+            "mixreduce", self._wf_default["mixreduce"])
+        self.ctx.nsteps = wf_dict.get("nsteps", self._wf_default["nsteps"])
+        self.ctx.threshold_aggressive_mixing = wf_dict.get(
+            "threshold_aggressive_mixing", self._wf_default["threshold_aggressive_mixing"])
+        self.ctx.threshold_switch_high_accuracy = wf_dict.get(
+            "threshold_switch_high_accuracy", self._wf_default["threshold_switch_high_accuracy"])
 
         # initial magnetization
-        self.ctx.mag_init = wf_dict.get('mag_init', self._wf_default['mag_init'])
-        self.ctx.hfield = wf_dict.get('hfield', self._wf_default['hfield'])
-        self.ctx.xinit = wf_dict.get('init_pos', self._wf_default['init_pos'])
+        self.ctx.mag_init = wf_dict.get(
+            "mag_init", self._wf_default["mag_init"])
+        self.ctx.hfield = wf_dict.get("hfield", self._wf_default["hfield"])
+        self.ctx.xinit = wf_dict.get("init_pos", self._wf_default["init_pos"])
         self.ctx.mag_init_step_success = False
 
         # difference in eV to emin (e_fermi) if emin (emax) are larger (smaller) than emin (e_fermi)
-        self.ctx.delta_e = wf_dict.get('delta_e_min', self._wf_default['delta_e_min'])
+        self.ctx.delta_e = wf_dict.get(
+            "delta_e_min", self._wf_default["delta_e_min"])
         # threshold for dos comparison (comparison of dos at emin)
-        self.ctx.threshold_dos_zero = wf_dict.get('threshold_dos_zero', self._wf_default['threshold_dos_zero'])
+        self.ctx.threshold_dos_zero = wf_dict.get(
+            "threshold_dos_zero", self._wf_default["threshold_dos_zero"])
         self.ctx.efermi = None
-        
+
         # set starting noco angles, gets updated in between the KKR runs if fix_dir == False for all atoms
-        if 'initial_noco_angles' in self.inputs:
+        if "initial_noco_angles" in self.inputs:
             self.ctx.initial_noco_angles = self.inputs.initial_noco_angles
-            self.ctx.fix_dir_threshold = wf_dict.get('fix_dir_threshold', self._wf_default['fix_dir_threshold'])
+            self.ctx.fix_dir_threshold = wf_dict.get(
+                "fix_dir_threshold", self._wf_default["fix_dir_threshold"])
 
         # retreive dos data in each scf run
-        self.ctx.scf_dosdata = wf_dict.get('retreive_dos_data_scf_run', self._wf_default['retreive_dos_data_scf_run'])
+        self.ctx.scf_dosdata = wf_dict.get(
+            "retreive_dos_data_scf_run", self._wf_default["retreive_dos_data_scf_run"])
 
-        self.report('INFO: use the following parameter:\n'
-                    '\nGeneral settings\n'
-                    'use mpi: {}\n'
-                    'max number of KKR runs: {}\n'
-                    'Resources: {}\n'
-                    'Walltime (s): {}\n'
-                    'queue name: {}\n'
-                    'scheduler command: {}\n'
-                    'description: {}\n'
-                    'label: {}\n'
-                    '\nMixing parameter\n'
-                    'Straight mixing factor: {}\n'
-                    'Anderson mixing factor: {}\n'
-                    'Nsteps scf cycle: {}\n'
-                    'Convergence criterion: {}\n'
-                    'threshold_aggressive_mixing: {}\n'
-                    'threshold_switch_high_accuracy: {}\n'
-                    'convergence_setting_coarse: {}\n'
-                    'convergence_setting_fine: {}\n'
-                    'factor reduced mixing if failing calculation: {}\n'
-                    '\nAdditional parameter\n'
-                    'check DOS between runs: {}\n'
-                    'DOS parameters: {}\n'
-                    'init magnetism in first step: {}\n'
-                    'init magnetism, hfield: {}\n'
-                    'init magnetism, init_pos: {}\n'
-                    ''.format(self.ctx.withmpi, self.ctx.max_number_runs,
-                                self.ctx.resources, self.ctx.max_wallclock_seconds,
-                                self.ctx.queue, self.ctx.custom_scheduler_commands,
-                                self.ctx.description_wf, self.ctx.label_wf,
-                                self.ctx.strmix, self.ctx.brymix, self.ctx.nsteps,
-                                self.ctx.convergence_criterion,
-                                self.ctx.threshold_aggressive_mixing,
-                                self.ctx.threshold_switch_high_accuracy,
-                                self.ctx.convergence_setting_coarse,
-                                self.ctx.convergence_setting_fine,
-                                self.ctx.mixreduce, self.ctx.check_dos,
-                                self.ctx.dos_params, self.ctx.mag_init,
-                                self.ctx.hfield, self.ctx.xinit)
+        self.report("INFO: use the following parameter:\n"
+                    "\nGeneral settings\n"
+                    "use mpi: {}\n"
+                    "max number of KKR runs: {}\n"
+                    "Resources: {}\n"
+                    "Walltime (s): {}\n"
+                    "queue name: {}\n"
+                    "scheduler command: {}\n"
+                    "description: {}\n"
+                    "label: {}\n"
+                    "\nMixing parameter\n"
+                    "Straight mixing factor: {}\n"
+                    "Anderson mixing factor: {}\n"
+                    "Nsteps scf cycle: {}\n"
+                    "Convergence criterion: {}\n"
+                    "threshold_aggressive_mixing: {}\n"
+                    "threshold_switch_high_accuracy: {}\n"
+                    "convergence_setting_coarse: {}\n"
+                    "convergence_setting_fine: {}\n"
+                    "factor reduced mixing if failing calculation: {}\n"
+                    "\nAdditional parameter\n"
+                    "check DOS between runs: {}\n"
+                    "DOS parameters: {}\n"
+                    "init magnetism in first step: {}\n"
+                    "init magnetism, hfield: {}\n"
+                    "init magnetism, init_pos: {}\n"
+                    "".format(self.ctx.withmpi, self.ctx.max_number_runs,
+                              self.ctx.resources, self.ctx.max_wallclock_seconds,
+                              self.ctx.queue, self.ctx.custom_scheduler_commands,
+                              self.ctx.description_wf, self.ctx.label_wf,
+                              self.ctx.strmix, self.ctx.brymix, self.ctx.nsteps,
+                              self.ctx.convergence_criterion,
+                              self.ctx.threshold_aggressive_mixing,
+                              self.ctx.threshold_switch_high_accuracy,
+                              self.ctx.convergence_setting_coarse,
+                              self.ctx.convergence_setting_fine,
+                              self.ctx.mixreduce, self.ctx.check_dos,
+                              self.ctx.dos_params, self.ctx.mag_init,
+                              self.ctx.hfield, self.ctx.xinit)
                     )
 
         # return para/vars
@@ -383,21 +423,23 @@ Can be skipped if a previous KkrCalculation is given with the `remote_data` inpu
         self.ctx.neutr = []
         self.ctx.warnings = []
         self.ctx.errors = []
-        self.ctx.formula = ''
+        self.ctx.formula = ""
 
         # for results table each list gets one entry per iteration that has been performed
-        self.ctx.KKR_steps_stats = {'success':[],
-                                    'isteps':[],
-                                    'imix':[],
-                                    'mixfac':[],
-                                    'qbound':[],
-                                    'high_sett':[],
-                                    'first_rms':[],
-                                    'last_rms':[],
-                                    'first_neutr':[],
-                                    'last_neutr':[],
-                                    'pk':[],
-                                    'uuid':[]}
+        self.ctx.KKR_steps_stats = {
+            "success": [],
+            "isteps": [],
+            "imix": [],
+            "mixfac": [],
+            "qbound": [],
+            "high_sett": [],
+            "first_rms": [],
+            "last_rms": [],
+            "first_neutr": [],
+            "last_neutr": [],
+            "pk": [],
+            "uuid": []
+        }
 
     def validate_input(self):
         """
@@ -407,48 +449,56 @@ Can be skipped if a previous KkrCalculation is given with the `remote_data` inpu
         run_voronoi = True
         inputs = self.inputs
 
-        if 'structure' in inputs:
-            self.report('INFO: Found structure in input. Start with Voronoi calculation.')
-            if not 'voronoi' in inputs:
+        if "structure" in inputs:
+            self.report(
+                "INFO: Found structure in input. Start with Voronoi calculation."
+            )
+            if not "voronoi" in inputs:
                 return self.exit_codes.ERROR_NO_VORONOI_CODE_GIVEN
-        elif 'remote_data' in inputs:
-            self.report('INFO: Found remote_data in input. Continue calculation without running voronoi step.')
+        elif "remote_data" in inputs:
+            self.report(
+                "INFO: Found remote_data in input. Continue calculation without running voronoi step."
+            )
             run_voronoi = False
         else:
             return self.exit_codes.ERROR_NOT_ENOUGH_INPUTS
 
-        if 'voronoi' in inputs:
+        if "voronoi" in inputs:
             try:
-                test_and_get_codenode(inputs.voronoi, 'kkr.voro', use_exceptions=True)
+                test_and_get_codenode(
+                    inputs.voronoi, "kkr.voro", use_exceptions=True)
             except ValueError:
                 return self.exit_codes.ERROR_INVALID_VORONOI_CODE
 
-        if 'kkr' in inputs:
+        if "kkr" in inputs:
             try:
-                test_and_get_codenode(inputs.kkr, 'kkr.kkr', use_exceptions=True)
+                test_and_get_codenode(
+                    inputs.kkr, "kkr.kkr", use_exceptions=True)
             except ValueError:
                 return self.exit_codes.ERROR_INVALID_KKR_CODE
 
         # set params and remote folder to input if voronoi step is skipped
         if not run_voronoi:
             self.ctx.last_remote = inputs.remote_data
-            num_parents = len(self.ctx.last_remote.get_incoming(node_class=CalcJobNode).all_link_labels())
+            num_parents = len(self.ctx.last_remote.get_incoming(
+                node_class=CalcJobNode).all_link_labels())
             if num_parents == 0:
-                pk_last_remote = self.ctx.last_remote.inputs.last_RemoteData.outputs.output_kkr_scf_wc_ParameterResults.get_dict().get('last_calc_nodeinfo').get('pk')
+                pk_last_remote = self.ctx.last_remote.inputs.last_RemoteData.outputs.output_kkr_scf_wc_ParameterResults.get_dict(
+                ).get("last_calc_nodeinfo").get("pk")
                 last_calc = load_node(pk_last_remote)
                 self.ctx.last_remote = last_calc.outputs.remote_folder
-            try: # first try parent of remote data output of a previous calc.
+            try:  # first try parent of remote data output of a previous calc.
                 parent_params = get_parent_paranode(inputs.remote_data)
             except AttributeError:
-                try: # next try to extract parameter from previous kkr_scf_wc output
+                try:  # next try to extract parameter from previous kkr_scf_wc output
                     parent_params = inputs.remote_data.inputs.last_RemoteData.inputs.calc_parameters
                 except AttributeError:
                     return self.exit_codes.ERROR_NO_PARENT_PARAMS_FOUND
-            if  'calc_parameters' in inputs:
+            if "calc_parameters" in inputs:
                 self.ctx.last_params = inputs.calc_parameters
                 # TODO: check last_params consistency against parent_params
                 #parent_params_dict = parent_params.get_dict()
-                #for key, val in self.ctx.last_params.get_dict().iteritems():
+                # for key, val in self.ctx.last_params.get_dict().iteritems():
                 #    if key in parent_params_dict.keys():
                 #        if val != parent_params_dict[key]:
                 #
@@ -459,7 +509,6 @@ Can be skipped if a previous KkrCalculation is given with the `remote_data` inpu
             self.ctx.voro_step_success = True
 
         return run_voronoi
-
 
     def run_voronoi(self):
         """
@@ -473,7 +522,7 @@ Can be skipped if a previous KkrCalculation is given with the `remote_data` inpu
         kkrcode = self.inputs.kkr
 
         # set KKR parameters if any are given, otherwise use defaults
-        if 'calc_parameters' in self.inputs:
+        if "calc_parameters" in self.inputs:
             params = self.inputs.calc_parameters
         else:
             params = None
@@ -482,20 +531,23 @@ Can be skipped if a previous KkrCalculation is given with the `remote_data` inpu
         defaults, version = kkrparams.get_KKRcalc_parameter_defaults()
         if params is None:
             params = Dict(dict=defaults)
-            params.label = 'default values'
+            params.label = "default values"
         newparams = {}
         for key, val in defaults.items():
             if params.get_dict().get(key, None) is None:
-                if key != 'RCLUSTZ': # this one is automatically set by kkr_startpot_wc so we skip it here
+                if key != "RCLUSTZ":  # this one is automatically set by kkr_startpot_wc so we skip it here
                     newparams[key] = val
-                    self.report("INFO: Automatically added default values to KKR parameters: {} {}".format(key, val))
-        if newparams!={}:
+                    self.report(
+                        "INFO: Automatically added default values to KKR parameters: {} {}"
+                        .format(key, val)
+                    )
+        if newparams != {}:
             for key, val in params.get_dict().items():
                 if val is not None:
                     newparams[key] = val
             updatenode = Dict(dict=newparams)
-            updatenode.label = 'added defaults to KKR input parameter'
-            updatenode.description = 'Overwritten KKR input parameter to correct missing default values automatically'
+            updatenode.label = "added defaults to KKR input parameter"
+            updatenode.description = "Overwritten KKR input parameter to correct missing default values automatically"
             params = update_params_wf(params, updatenode)
 
         # set nspin to 2 if mag_init is used
@@ -504,16 +556,21 @@ Can be skipped if a previous KkrCalculation is given with the `remote_data` inpu
             para_check = kkrparams()
             for key, val in input_dict.items():
                 para_check.set_value(key, val, silent=True)
-            nspin_in = para_check.get_value('NSPIN')
+            nspin_in = para_check.get_value("NSPIN")
             if nspin_in is None:
                 nspin_in = 1
             if nspin_in < 2:
-                self.report('WARNING: found NSPIN=1 but for maginit needs NPIN=2. Overwrite this automatically')
-                para_check.set_value('NSPIN', 2, silent=True)
-                self.report("INFO: update parameters to: {}".format(para_check.get_set_values()))
+                self.report(
+                    "WARNING: found NSPIN=1 but for maginit needs NPIN=2. Overwrite this automatically"
+                )
+                para_check.set_value("NSPIN", 2, silent=True)
+                self.report(
+                    "INFO: update parameters to: {}"
+                    .format(para_check.get_set_values())
+                )
                 updatenode = Dict(dict=para_check.get_dict())
-                updatenode.label = 'overwritten KKR input parameters'
-                updatenode.description = 'Overwritten KKR input parameter to correct NSPIN to 2'
+                updatenode.label = "overwritten KKR input parameters"
+                updatenode.description = "Overwritten KKR input parameter to correct NSPIN to 2"
                 params = update_params_wf(params, updatenode)
 
         # check consistency of input parameters before running calculation
@@ -522,7 +579,7 @@ Can be skipped if a previous KkrCalculation is given with the `remote_data` inpu
         # set parameters of voro_start sub workflow
         sub_wf_params_dict = kkr_startpot_wc.get_wf_defaults(silent=True)
         label, description = "voro_start_default_params", "workflow parameters for voro_start"
-        if 'wf_parameters' in self.inputs:
+        if "wf_parameters" in self.inputs:
             wf_params_input = self.inputs.wf_parameters.get_dict()
             num_updated = 0
             for key in list(sub_wf_params_dict.keys()):
@@ -536,12 +593,18 @@ Can be skipped if a previous KkrCalculation is given with the `remote_data` inpu
         sub_wf_params.label = label
         sub_wf_params.description = description
 
-        self.report('INFO: run voronoi step')
-        self.report('INFO: using calc_params ({}): {}'.format(params, params.get_dict()))
-        self.report('INFO: using wf_parameters ({}): {}'.format(sub_wf_params, sub_wf_params.get_dict()))
+        self.report("INFO: run voronoi step")
+        self.report(
+            "INFO: using calc_params ({}): {}"
+            .format(params, params.get_dict())
+        )
+        self.report(
+            "INFO: using wf_parameters ({}): {}"
+            .format(sub_wf_params, sub_wf_params.get_dict())
+        )
 
-        wf_label= 'kkr_startpot (voronoi)'
-        wf_desc = 'subworkflow to set up the input of a KKR calculation'
+        wf_label = "kkr_startpot (voronoi)"
+        wf_desc = "subworkflow to set up the input of a KKR calculation"
         builder = kkr_startpot_wc.get_builder()
         builder.kkr = kkrcode
         builder.voronoi = voronoicode
@@ -551,12 +614,11 @@ Can be skipped if a previous KkrCalculation is given with the `remote_data` inpu
         builder.metadata.label = wf_label
         builder.metadata.description = wf_desc
         builder.options = self.ctx.options_params_dict
-        if 'startpot_overwrite' in self.inputs:
+        if "startpot_overwrite" in self.inputs:
             builder.startpot_overwrite = self.inputs.startpot_overwrite
         future = self.submit(builder)
 
         return ToContext(voronoi=future, last_calc=future)
-
 
     def check_voronoi(self):
         """
@@ -568,7 +630,7 @@ Can be skipped if a previous KkrCalculation is given with the `remote_data` inpu
 
         # check some output
         kkrstartpot_results = self.ctx.voronoi.outputs.results_vorostart_wc.get_dict()
-        if kkrstartpot_results['successful']:
+        if kkrstartpot_results["successful"]:
             voro_step_ok = True
         # initialize last_remote and last_params (gets updated in loop of KKR calculations)
         self.ctx.last_params = self.ctx.voronoi.outputs.last_params_voronoi
@@ -583,21 +645,20 @@ Can be skipped if a previous KkrCalculation is given with the `remote_data` inpu
 
         self.report("INFO: done checking voronoi output")
 
-
     def condition(self):
         """
         check convergence condition
         """
         self.report("INFO: checking condition for kkr step")
         do_kkr_step = True
-        stopreason = ''
+        stopreason = ""
 
-        #increment KKR runs loop counter
+        # increment KKR runs loop counter
         self.ctx.loop_count += 1
 
         # check if initial step was succesful
         if not self.ctx.voro_step_success:
-            stopreason = 'voronoi step unsucessful'
+            stopreason = "voronoi step unsucessful"
             do_kkr_step = False
             return do_kkr_step
 
@@ -606,7 +667,7 @@ Can be skipped if a previous KkrCalculation is given with the `remote_data` inpu
             if not self.ctx.kkr_higher_accuracy:
                 do_kkr_step = do_kkr_step & True
             else:
-                stopreason = 'KKR converged'
+                stopreason = "KKR converged"
                 do_kkr_step = False
         else:
             do_kkr_step = do_kkr_step & True
@@ -619,16 +680,18 @@ Can be skipped if a previous KkrCalculation is given with the `remote_data` inpu
             else:
                 do_kkr_step = False
                 # TODO do this differently, return of exit code needs to be done outside of while loop!
-                #return self.exit_codes.ERROR_MAX_KKR_RESTARTS_REACHED
+                # return self.exit_codes.ERROR_MAX_KKR_RESTARTS_REACHED
                 return do_kkr_step
 
-        self.report("INFO: done checking condition for kkr step (result={})".format(do_kkr_step))
+        self.report(
+            "INFO: done checking condition for kkr step (result={})"
+            .format(do_kkr_step)
+        )
 
         if not do_kkr_step:
             self.report("INFO: stopreason={}".format(stopreason))
 
         return do_kkr_step
-
 
     def update_kkr_params(self):
         """
@@ -637,7 +700,7 @@ Can be skipped if a previous KkrCalculation is given with the `remote_data` inpu
         self.report("INFO: updating kkr param step")
         decrease_mixing_fac = False
         switch_agressive_mixing = False
-        switch_higher_accuracy= False
+        switch_higher_accuracy = False
         initial_settings = False
 
         # only do something other than somple mixing after first kkr run
@@ -647,71 +710,102 @@ Can be skipped if a previous KkrCalculation is given with the `remote_data` inpu
                 try:
                     # check if calculation did start (maybe cluster had some hiccup)
                     calc = self.ctx.calcs[-1]
-                    has_output_node = len(calc.get_outgoing(link_label_filter='output_parameters').all())>0
-                    self.report("INFO: last KKR calculation failed. Probably because the cluster had some issue. Try to resubmit the same calculation")
+                    has_output_node = len(
+                        calc
+                        .get_outgoing(link_label_filter="output_parameters")
+                        .all()
+                    ) > 0
+                    self.report(
+                        "INFO: last KKR calculation failed. Probably because the cluster had some issue. Try to resubmit the same calculation"
+                    )
                 except:
                     # otherwise try to decrease the mixing factor
                     decrease_mixing_fac = True
-                    self.report("INFO: last KKR calculation failed. Trying to decrease mixfac")
+                    self.report(
+                        "INFO: last KKR calculation failed. Trying to decrease mixfac"
+                    )
 
             convergence_on_track = self.convergence_on_track()
 
             # check if calculation was on its way to converge
             if not convergence_on_track:
                 decrease_mixing_fac = True
-                self.report("INFO: last KKR did not converge. trying decreasing mixfac")
-                self.report("INFO: ctx.calcs: {} {}".format(self.ctx.calcs, type(self.ctx.calcs)))
+                self.report(
+                    "INFO: last KKR did not converge. trying decreasing mixfac"
+                )
+                self.report(
+                    "INFO: ctx.calcs: {} {}"
+                    .format(self.ctx.calcs, type(self.ctx.calcs))
+                )
                 # reset last_remote to last successful calculation
-                calclist = list(range(len(self.ctx.calcs))) # needs to be list because `(x)range` does not support slicing
-                if len(calclist)>1: calclist = calclist[::-1] # go backwards through list
+                # needs to be list because `(x)range` does not support slicing
+                calclist = list(range(len(self.ctx.calcs)))
+                if len(calclist) > 1:
+                    calclist = calclist[::-1]  # go backwards through list
                 for icalc in calclist:
-                    self.report("INFO: last calc success? {} {}".format(icalc, self.ctx.KKR_steps_stats['success'][icalc]))
-                    if self.ctx.KKR_steps_stats['success'][icalc]:
+                    self.report("INFO: last calc success? {} {}".format(
+                        icalc, self.ctx.KKR_steps_stats["success"][icalc]))
+                    if self.ctx.KKR_steps_stats["success"][icalc]:
                         self.ctx.last_remote = self.ctx.calcs[icalc].outputs.remote_folder
-                        break # exit loop if last_remote was found successfully
+                        break  # exit loop if last_remote was found successfully
                     else:
                         self.ctx.last_remote = None
                 # if no previous calculation was succesful take voronoi output or remote data from input (depending on the inputs)
-                self.report("INFO: last_remote is None? {} {}".format(self.ctx.last_remote is None, 'structure' in self.inputs))
+                self.report("INFO: last_remote is None? {} {}".format(
+                    self.ctx.last_remote is None, "structure" in self.inputs))
                 if self.ctx.last_remote is None:
-                    if 'structure' in self.inputs:
+                    if "structure" in self.inputs:
                         self.ctx.voronoi.outputs.last_voronoi_remote
                     else:
                         self.ctx.last_remote = self.inputs.remote_data
                 # check if last_remote has finally been set and abort if this is not the case
-                self.report("INFO: last_remote is still None? {}".format(self.ctx.last_remote is None))
+                self.report(
+                    "INFO: last_remote is still None? {}"
+                    .format(self.ctx.last_remote is None)
+                )
                 if self.ctx.last_remote is None:
                     return self.exit_codes.ERROR_LAST_REMOTE_NOT_FOUND
 
             # check if mixing strategy should be changed
-            last_mixing_scheme = self.ctx.last_params.get_dict()['IMIX']
+            last_mixing_scheme = self.ctx.last_params.get_dict()["IMIX"]
             if last_mixing_scheme is None:
                 last_mixing_scheme = 0
 
             if convergence_on_track:
                 last_rms = self.ctx.last_rms_all[-1]
 
-                if last_rms < self.ctx.threshold_aggressive_mixing and last_mixing_scheme == 0:
+                if (
+                    last_rms < self.ctx.threshold_aggressive_mixing
+                    and last_mixing_scheme == 0
+                ):
                     switch_agressive_mixing = True
-                    self.report("INFO: rms low enough, switch to agressive mixing")
+                    self.report(
+                        "INFO: rms low enough, switch to agressive mixing"
+                    )
 
                 # check if switch to higher accuracy should be done
                 if not self.ctx.kkr_higher_accuracy:
                     if last_rms < self.ctx.threshold_switch_high_accuracy:
                         switch_higher_accuracy = True
-                        self.report("INFO: rms low enough, switch to higher accuracy settings")
+                        self.report(
+                            "INFO: rms low enough, switch to higher accuracy settings"
+                        )
         else:
             initial_settings = True
 
         # if needed update parameters
-        if decrease_mixing_fac or switch_agressive_mixing or switch_higher_accuracy or initial_settings or self.ctx.mag_init:
+        if (
+            decrease_mixing_fac or switch_agressive_mixing
+            or switch_higher_accuracy or initial_settings
+            or self.ctx.mag_init
+        ):
 
             if initial_settings:
-                label = 'initial KKR scf parameters'
-                description = 'initial parameter set for scf calculation'
+                label = "initial KKR scf parameters"
+                description = "initial parameter set for scf calculation"
             else:
-                label = ''
-                description = ''
+                label = ""
+                description = ""
 
             # step 1: extract info from last input parameters and check consistency
             params = self.ctx.last_params
@@ -734,19 +828,25 @@ Can be skipped if a previous KkrCalculation is given with the `remote_data` inpu
                     if key_default in missing_list:
                         new_params[key_default] = kkrdefaults.get(key_default)
                         kkrdefaults_updated.append(key_default)
-                if len(kkrdefaults_updated)>0:
-                    self.report('ERROR: calc_parameters misses keys: {}'.format(missing_list))
+                if len(kkrdefaults_updated) > 0:
+                    self.report(
+                        "ERROR: calc_parameters misses keys: {}"
+                        .format(missing_list)
+                    )
                     return self.exit_codes.ERROR_CALC_PARAMTERS_INCOMPLETE
                 else:
-                    self.report('updated KKR parameter node with default values: {}'.format(kkrdefaults_updated))
+                    self.report(
+                        "updated KKR parameter node with default values: {}"
+                        .format(kkrdefaults_updated)
+                    )
 
             # step 2: change parameter (contained in new_params dictionary)
-            if initial_settings and 'structure' in self.inputs:
+            if initial_settings and "structure" in self.inputs:
                 # make sure to ignore IMIX from input node (start with simple mixing even if IMIX is set otherwise)
                 # this is enforced whenever voronoi step is starting point (otherwise you may want to continue a preconverged calculation)
                 last_mixing_scheme = None
             else:
-                last_mixing_scheme = para_check.get_value('IMIX')
+                last_mixing_scheme = para_check.get_value("IMIX")
             if last_mixing_scheme is None:
                 last_mixing_scheme = 0
 
@@ -755,99 +855,126 @@ Can be skipped if a previous KkrCalculation is given with the `remote_data` inpu
             nsteps = self.ctx.nsteps
 
             # add number of scf steps
-            new_params['NSTEPS'] = nsteps
+            new_params["NSTEPS"] = nsteps
 
             # step 2.1 fill new_params dict with values to be updated
             if decrease_mixing_fac:
                 if last_mixing_scheme == 0:
-                    self.report('(strmixfax, mixreduce)= ({}, {})'.format(strmixfac, self.ctx.mixreduce))
-                    self.report('type(strmixfax, mixreduce)= {} {}'.format(type(strmixfac), type(self.ctx.mixreduce)))
+                    self.report(
+                        "(strmixfax, mixreduce)= ({}, {})"
+                        .format(strmixfac, self.ctx.mixreduce)
+                    )
+                    self.report(
+                        "type(strmixfax, mixreduce)= {} {}"
+                        .format(type(strmixfac), type(self.ctx.mixreduce))
+                    )
                     strmixfac = strmixfac * self.ctx.mixreduce
                     self.ctx.strmix = strmixfac
-                    label += 'decreased_mix_fac_str (step {})'.format(self.ctx.loop_count)
-                    description += 'decreased STRMIX factor by {}'.format(self.ctx.mixreduce)
+                    label += "decreased_mix_fac_str (step {})".format(
+                        self.ctx.loop_count)
+                    description += "decreased STRMIX factor by {}".format(
+                        self.ctx.mixreduce)
                 else:
-                    self.report('(brymixfax, mixreduce)= ({}, {})'.format(brymixfac, self.ctx.mixreduce))
-                    self.report('type(brymixfax, mixreduce)= {} {}'.format(type(brymixfac), type(self.ctx.mixreduce)))
+                    self.report(
+                        "(brymixfax, mixreduce)= ({}, {})"
+                        .format(brymixfac, self.ctx.mixreduce)
+                    )
+                    self.report(
+                        "type(brymixfax, mixreduce)= {} {}"
+                        .format(type(brymixfac), type(self.ctx.mixreduce))
+                    )
                     brymixfac = brymixfac * self.ctx.mixreduce
                     self.ctx.brymix = brymixfac
-                    label += 'decreased_mix_fac_bry'
-                    description += 'decreased BRYMIX factor by {}'.format(self.ctx.mixreduce)
+                    label += "decreased_mix_fac_bry"
+                    description += "decreased BRYMIX factor by {}".format(
+                        self.ctx.mixreduce)
 
-            #add mixing factor
-            new_params['STRMIX'] = strmixfac
-            new_params['BRYMIX'] = brymixfac
+            # add mixing factor
+            new_params["STRMIX"] = strmixfac
+            new_params["BRYMIX"] = brymixfac
 
             if switch_agressive_mixing:
                 last_mixing_scheme = 5
-                label += ' switched_to_agressive_mixing'
-                description += ' switched to agressive mixing scheme (IMIX={})'.format(last_mixing_scheme)
+                label += " switched_to_agressive_mixing"
+                description += " switched to agressive mixing scheme (IMIX={})".format(
+                    last_mixing_scheme)
 
             # add mixing scheme
-            new_params['IMIX'] = last_mixing_scheme
+            new_params["IMIX"] = last_mixing_scheme
             self.ctx.last_mixing_scheme = last_mixing_scheme
 
             if switch_higher_accuracy:
                 self.ctx.kkr_higher_accuracy = True
                 convergence_settings = self.ctx.convergence_setting_fine
-                label += ' use_higher_accuracy'
-                description += ' using higher accuracy settings goven in convergence_setting_fine'
+                label += " use_higher_accuracy"
+                description += " using higher accuracy settings goven in convergence_setting_fine"
             else:
                 convergence_settings = self.ctx.convergence_setting_coarse
 
             # slightly increase temperature if previous calculation was unsuccessful for the second time
             if decrease_mixing_fac and not self.convergence_on_track():
-                self.report('INFO: last calculation did not converge and convergence not on track. Try to increase temperature by 50K.')
-                convergence_settings['tempr'] += 50.
-                label += ' TEMPR+50K'
-                description += ' with increased temperature of 50K'
+                self.report(
+                    "INFO: last calculation did not converge and convergence not on track. Try to increase temperature by 50K."
+                )
+                convergence_settings["tempr"] += 50.
+                label += " TEMPR+50K"
+                description += " with increased temperature of 50K"
 
             # add convegence settings
             if self.ctx.loop_count == 1 or self.ctx.last_mixing_scheme == 0:
-                new_params['QBOUND'] = self.ctx.threshold_aggressive_mixing
+                new_params["QBOUND"] = self.ctx.threshold_aggressive_mixing
             else:
-                new_params['QBOUND'] = self.ctx.convergence_criterion
-            new_params['NPOL'] = convergence_settings['npol']
-            new_params['NPT1'] = convergence_settings['n1']
-            new_params['NPT2'] = convergence_settings['n2']
-            new_params['NPT3'] = convergence_settings['n3']
-            new_params['TEMPR'] = convergence_settings['tempr']
-            new_params['BZDIVIDE'] = convergence_settings['kmesh']
+                new_params["QBOUND"] = self.ctx.convergence_criterion
+            new_params["NPOL"] = convergence_settings["npol"]
+            new_params["NPT1"] = convergence_settings["n1"]
+            new_params["NPT2"] = convergence_settings["n2"]
+            new_params["NPT3"] = convergence_settings["n3"]
+            new_params["TEMPR"] = convergence_settings["tempr"]
+            new_params["BZDIVIDE"] = convergence_settings["kmesh"]
 
             # initial magnetization
             if initial_settings and self.ctx.mag_init:
                 if self.ctx.hfield <= 0:
-                    self.report('\nWARNING: magnetization initialization chosen but hfield is zero. Automatically change back to default value (hfield={})\n'.format(self._wf_default['hfield']))
-                    self.ctx.hfield = self._wf_default['hfield']
+                    self.report(
+                        "\nWARNING: magnetization initialization chosen but hfield is zero. Automatically change back to default value (hfield={})\n"
+                        .format(self._wf_default["hfield"])
+                    )
+                    self.ctx.hfield = self._wf_default["hfield"]
                 xinipol = self.ctx.xinit
                 if xinipol is None:
                     # find structure to determine needed length on xinipol
-                    if 'structure' in self.inputs:
+                    if "structure" in self.inputs:
                         struc = self.inputs.structure
                     else:
-                        struc, voro_parent = VoronoiCalculation.find_parent_structure(self.ctx.last_remote)
+                        struc, voro_parent = VoronoiCalculation.find_parent_structure(
+                            self.ctx.last_remote)
                     natom = len(struc.sites)
                     xinipol = ones(natom)
-                new_params['LINIPOL'] = True
-                new_params['HFIELD'] = self.ctx.hfield
-                new_params['XINIPOL'] = xinipol
-            elif self.ctx.mag_init and self.ctx.mag_init_step_success: # turn off initialization after first (successful) iteration
-                new_params['LINIPOL'] = False
-                new_params['HFIELD'] = 0.0
+                new_params["LINIPOL"] = True
+                new_params["HFIELD"] = self.ctx.hfield
+                new_params["XINIPOL"] = xinipol
+            # turn off initialization after first (successful) iteration
+            elif self.ctx.mag_init and self.ctx.mag_init_step_success:
+                new_params["LINIPOL"] = False
+                new_params["HFIELD"] = 0.0
             elif not self.ctx.mag_init:
-                self.report("INFO: mag_init is False. Overwrite 'HFIELD' to '0.0' and 'LINIPOL' to 'False'.")
+                self.report(
+                    "INFO: mag_init is False. Overwrite 'HFIELD' to '0.0' and 'LINIPOL' to 'False'."
+                )
                 # reset mag init to avoid reinitializing
-                new_params['HFIELD'] = 0.0
-                new_params['LINIPOL'] = False
+                new_params["HFIELD"] = 0.0
+                new_params["LINIPOL"] = False
 
             # set nspin to 2 if mag_init is used
             if self.ctx.mag_init:
-                nspin_in = para_check.get_value('NSPIN')
+                nspin_in = para_check.get_value("NSPIN")
                 if nspin_in is None:
                     nspin_in = 1
                 if nspin_in < 2:
-                    self.report('WARNING: found NSPIN=1 but for maginit needs NPIN=2. Overwrite this automatically')
-                    new_params['NSPIN'] = 2
+                    self.report(
+                        "WARNING: found NSPIN=1 but for maginit needs NPIN=2. Overwrite this automatically"
+                    )
+                    new_params["NSPIN"] = 2
 
             # step 2.2 update values
             try:
@@ -857,7 +984,10 @@ Can be skipped if a previous KkrCalculation is given with the `remote_data` inpu
                 return self.exit_codes.ERROR_PARAM_UPDATE_FAILED
 
             # step 3:
-            self.report("INFO: update parameters to: {}".format(para_check.get_set_values()))
+            self.report(
+                "INFO: update parameters to: {}"
+                .format(para_check.get_set_values())
+            )
             updatenode = Dict(dict=para_check.get_dict())
             updatenode.label = label
             updatenode.description = description
@@ -869,36 +999,44 @@ Can be skipped if a previous KkrCalculation is given with the `remote_data` inpu
 
         self.report("INFO: done updating kkr param step")
 
-
     def run_kkr(self):
         """
         submit a KKR calculation
         """
-        self.report("INFO: setting up kkr calculation step {}".format(self.ctx.loop_count))
+        self.report(
+            "INFO: setting up kkr calculation step {}"
+            .format(self.ctx.loop_count)
+        )
 
-        label = 'KKR calculation step {} (IMIX={})'.format(self.ctx.loop_count, self.ctx.last_mixing_scheme)
-        description = 'KKR calculation of step {}, using mixing scheme {}'.format(self.ctx.loop_count, self.ctx.last_mixing_scheme)
+        label = "KKR calculation step {} (IMIX={})".format(
+            self.ctx.loop_count, self.ctx.last_mixing_scheme)
+        description = "KKR calculation of step {}, using mixing scheme {}".format(
+            self.ctx.loop_count, self.ctx.last_mixing_scheme)
         code = self.inputs.kkr
         remote = self.ctx.last_remote
         params = self.ctx.last_params
-        options = {"max_wallclock_seconds": self.ctx.max_wallclock_seconds,
-                   "resources": self.ctx.resources,
-                   "queue_name" : self.ctx.queue}
+        options = {
+            "max_wallclock_seconds": self.ctx.max_wallclock_seconds,
+            "resources": self.ctx.resources,
+            "queue_name": self.ctx.queue
+        }
         if self.ctx.custom_scheduler_commands:
             options["custom_scheduler_commands"] = self.ctx.custom_scheduler_commands
 
-        inputs = get_inputs_kkr(code, remote, options, label, description, parameters=params, serial=(not self.ctx.withmpi))
+        inputs = get_inputs_kkr(
+            code, remote, options, label, description,
+            parameters=params, serial=(not self.ctx.withmpi)
+        )
 
         # pass nonco angles setting to KkrCalculation
-        if 'initial_noco_angles' in self.inputs:
-            inputs['initial_noco_angles'] = self.ctx.initial_noco_angles
+        if "initial_noco_angles" in self.inputs:
+            inputs["initial_noco_angles"] = self.ctx.initial_noco_angles
 
         # run the KKR calculation
-        self.report('INFO: doing calculation')
+        self.report("INFO: doing calculation")
         kkr_run = self.submit(KkrCalculation, **inputs)
 
         return ToContext(kkr=kkr_run, last_calc=kkr_run)
-
 
     def inspect_kkr(self):
         """
@@ -906,7 +1044,9 @@ Can be skipped if a previous KkrCalculation is given with the `remote_data` inpu
         """
         self.report("INFO: inspecting kkr results step")
 
-        self.report("Caching info: {}".format(self.ctx.last_calc.get_cache_source()))
+        self.report(
+            "Caching info: {}".format(self.ctx.last_calc.get_cache_source())
+        )
 
         self.ctx.calcs.append(self.ctx.last_calc)
         self.ctx.kkr_step_success = True
@@ -916,16 +1056,20 @@ Can be skipped if a previous KkrCalculation is given with the `remote_data` inpu
             self.ctx.kkr_step_success = False
             self.report("ERROR: last calculation not finished correctly")
 
-        self.report("INFO: kkr_step_success: {}".format(self.ctx.kkr_step_success))
+        self.report(
+            "INFO: kkr_step_success: {}".format(self.ctx.kkr_step_success)
+        )
 
         # extract convergence info about rms etc. (used to determine convergence behavior)
         try:
-            self.report("INFO: trying to find output of last_calc: {}".format(self.ctx.last_calc))
+            self.report("INFO: trying to find output of last_calc: {}".format(
+                self.ctx.last_calc))
             last_calc_output = self.ctx.last_calc.outputs.output_parameters.get_dict()
             found_last_calc_output = True
         except:
             found_last_calc_output = False
-        self.report("INFO: found_last_calc_output: {}".format(found_last_calc_output))
+        self.report("INFO: found_last_calc_output: {}".format(
+            found_last_calc_output))
 
         # try to extract remote folder
         try:
@@ -938,12 +1082,14 @@ Can be skipped if a previous KkrCalculation is given with the `remote_data` inpu
 
         if self.ctx.kkr_step_success and found_last_calc_output:
             # check convergence
-            self.ctx.kkr_converged = last_calc_output['convergence_group']['calculation_converged']
+            self.ctx.kkr_converged = last_calc_output["convergence_group"]["calculation_converged"]
             # check rms, compare spin and charge values and take bigger one
-            rms_charge = last_calc_output['convergence_group']['rms']
-            rms_spin = last_calc_output['convergence_group'].get('rms_spin', 0) # returning 0 if not found allows to reuse older verisons (e.g. in caching)
-            if rms_spin is None: rms_spin = 0 # this happens for NSPIN==1
-            if rms_charge>=rms_spin:
+            rms_charge = last_calc_output["convergence_group"]["rms"]
+            # returning 0 if not found allows to reuse older verisons (e.g. in caching)
+            rms_spin = last_calc_output["convergence_group"].get("rms_spin", 0)
+            if rms_spin is None:
+                rms_spin = 0  # this happens for NSPIN==1
+            if rms_charge >= rms_spin:
                 rms_max = rms_charge
                 use_rms_charge = True
             else:
@@ -951,12 +1097,16 @@ Can be skipped if a previous KkrCalculation is given with the `remote_data` inpu
                 use_rms_charge = False
             self.ctx.rms.append(rms_max)
             if use_rms_charge:
-                rms_all_iter_last_calc = list(last_calc_output['convergence_group']['rms_all_iterations'])
+                rms_all_iter_last_calc = list(
+                    last_calc_output["convergence_group"]["rms_all_iterations"])
             else:
-                rms_all_iter_last_calc = list(last_calc_output['convergence_group']['rms_spin_all_iterations'])
-            #check charge neutrality
-            self.ctx.neutr.append(last_calc_output['convergence_group']['charge_neutrality'])
-            neutr_all_iter_last_calc = list(last_calc_output['convergence_group']['charge_neutrality_all_iterations'])
+                rms_all_iter_last_calc = list(
+                    last_calc_output["convergence_group"]["rms_spin_all_iterations"])
+            # check charge neutrality
+            self.ctx.neutr.append(
+                last_calc_output["convergence_group"]["charge_neutrality"])
+            neutr_all_iter_last_calc = list(
+                last_calc_output["convergence_group"]["charge_neutrality_all_iterations"])
 
             # add lists of last iterations
             self.ctx.last_rms_all = rms_all_iter_last_calc
@@ -982,21 +1132,27 @@ Can be skipped if a previous KkrCalculation is given with the `remote_data` inpu
         # TODO: extract something else (maybe total energy, charge neutrality, magnetisation)?
 
         # store some statistics used to print table in the end of the report
-        tmplist = self.ctx.KKR_steps_stats.get('success',[])
-        self.report('INFO: append kkr_step_success {}, {}'.format(tmplist, self.ctx.kkr_step_success))
+        tmplist = self.ctx.KKR_steps_stats.get("success", [])
+        self.report("INFO: append kkr_step_success {}, {}".format(
+            tmplist, self.ctx.kkr_step_success))
         tmplist.append(self.ctx.kkr_step_success)
-        self.ctx.KKR_steps_stats['success'] = tmplist
+        self.ctx.KKR_steps_stats["success"] = tmplist
         try:
-            isteps = self.ctx.last_calc.outputs.output_parameters.get_dict()['convergence_group']['number_of_iterations']
+            isteps = self.ctx.last_calc.outputs.output_parameters.get_dict(
+            )["convergence_group"]["number_of_iterations"]
         except:
-            self.ctx.warnings.append('cound not set isteps in KKR_steps_stats dict')
+            self.ctx.warnings.append(
+                "cound not set isteps in KKR_steps_stats dict"
+            )
             isteps = -1
 
         try:
             first_rms = self.ctx.last_rms_all[0]
             last_rms = self.ctx.last_rms_all[-1]
         except:
-            self.ctx.warnings.append('cound not set first_rms, last_rms in KKR_steps_stats dict')
+            self.ctx.warnings.append(
+                "cound not set first_rms, last_rms in KKR_steps_stats dict"
+            )
             first_rms = -1
             last_rms = -1
 
@@ -1004,7 +1160,8 @@ Can be skipped if a previous KkrCalculation is given with the `remote_data` inpu
             first_neutr = self.ctx.last_neutr_all[0]
             last_neutr = self.ctx.last_neutr_all[-1]
         except:
-            self.ctx.warnings.append('cound not set first_neutr, last_neutr in KKR_steps_stats dict')
+            self.ctx.warnings.append(
+                "cound not set first_neutr, last_neutr in KKR_steps_stats dict")
             first_neutr = -999
             last_neutr = -999
 
@@ -1019,37 +1176,36 @@ Can be skipped if a previous KkrCalculation is given with the `remote_data` inpu
             qbound = self.ctx.threshold_switch_high_accuracy
 
         # store results in KKR_steps_stats dict
-        for key, val in {'isteps': isteps, 'imix': self.ctx.last_mixing_scheme, 'mixfac': mixfac,
-                         'qbound': qbound, 'high_sett': self.ctx.kkr_higher_accuracy, 'first_rms': first_rms,
-                         'last_rms': last_rms, 'first_neutr': first_neutr, 'last_neutr': last_neutr,
-                         'pk': self.ctx.last_calc.pk, 'uuid': self.ctx.last_calc.uuid}.items():
-            tmplist = self.ctx.KKR_steps_stats.get(key,[])
+        for key, val in {"isteps": isteps, "imix": self.ctx.last_mixing_scheme, "mixfac": mixfac,
+                         "qbound": qbound, "high_sett": self.ctx.kkr_higher_accuracy, "first_rms": first_rms,
+                         "last_rms": last_rms, "first_neutr": first_neutr, "last_neutr": last_neutr,
+                         "pk": self.ctx.last_calc.pk, "uuid": self.ctx.last_calc.uuid}.items():
+            tmplist = self.ctx.KKR_steps_stats.get(key, [])
             tmplist.append(val)
             self.ctx.KKR_steps_stats[key] = tmplist
 
         # update noco angles
-        if 'initial_noco_angles' in self.inputs:
+        if "initial_noco_angles" in self.inputs:
             # do this only if previous calculation was successful
             if self.ctx.kkr_step_success and found_last_calc_output:
                 self._get_new_noco_angles()
 
-
         self.report("INFO: done inspecting kkr results step")
-
 
     def convergence_on_track(self):
         """
         Check if convergence behavior of the last calculation is on track (i.e. going down)
         """
         on_track = True
-        threshold = 5. # used to check condition if at least one of charnge_neutrality, rms-error goes down fast enough
+        threshold = 5.  # used to check condition if at least one of charnge_neutrality, rms-error goes down fast enough
         eps_neutr = 1e-4
         eps_rms = 1e-6
 
         # first check if previous calculation was stopped due to reaching the QBOUND limit
         try:
-            calc_reached_qbound = self.ctx.last_calc.outputs.output_parameters.get_dict()['convergence_group']['calculation_converged']
-        except: # captures error when last_calc dies not have an output node
+            calc_reached_qbound = self.ctx.last_calc.outputs.output_parameters.get_dict()[
+                "convergence_group"]["calculation_converged"]
+        except:  # captures error when last_calc dies not have an output node
             calc_reached_qbound = False
 
         if self.ctx.kkr_step_success and not calc_reached_qbound:
@@ -1063,31 +1219,46 @@ Can be skipped if a previous KkrCalculation is given with the `remote_data` inpu
             if first_rms == 0:
                 first_rms = 10**-16
             r, n = last_rms/first_rms, last_neutr/first_neutr
-            
+
             # deal with small differences
-            if abs(first_neutr-last_neutr)<eps_neutr:
+            if abs(first_neutr-last_neutr) < eps_neutr:
                 n = 0
-            if abs(first_rms-last_rms)>eps_rms:
+            if abs(first_rms-last_rms) > eps_rms:
                 r = 0
-                
-            self.report("INFO convergence check: first/last rms {}, {}; first/last neutrality {}, {}".format(first_rms, last_rms, first_neutr, last_neutr))
+
+            self.report(
+                "INFO convergence check: first/last rms {}, {}; first/last neutrality {}, {}"
+                .format(first_rms, last_rms, first_neutr, last_neutr)
+            )
             if r < 1 and n < 1:
-                self.report("INFO convergence check: both rms and neutrality go down")
+                self.report(
+                    "INFO convergence check: both rms and neutrality go down"
+                )
                 on_track = True
             elif n > threshold or r > threshold:
-                self.report("INFO convergence check: rms or neutrality goes up too fast, convergence is not expected")
+                self.report(
+                    "INFO convergence check: rms or neutrality goes up too fast, convergence is not expected"
+                )
                 on_track = False
             elif n*r < 1:
-                self.report("INFO convergence check: either rms goes up and neutrality goes down or vice versa")
-                self.report("INFO convergence check: but product goes down fast enough")
+                self.report(
+                    "INFO convergence check: either rms goes up and neutrality goes down or vice versa"
+                )
+                self.report(
+                    "INFO convergence check: but product goes down fast enough"
+                )
                 on_track = True
-            elif len(self.ctx.last_rms_all) ==1:
-                self.report("INFO convergence check: already converged after single iteration")
+            elif len(self.ctx.last_rms_all) == 1:
+                self.report(
+                    "INFO convergence check: already converged after single iteration"
+                )
                 on_track = True
             else:
-                self.report("INFO convergence check: rms or neutrality do not shrink fast enough, convergence is not expected")
+                self.report(
+                    "INFO convergence check: rms or neutrality do not shrink fast enough, convergence is not expected"
+                )
                 on_track = False
-                
+
         elif calc_reached_qbound:
             self.report("INFO convergence check: calculation reached QBOUND")
             on_track = True
@@ -1098,8 +1269,6 @@ Can be skipped if a previous KkrCalculation is given with the `remote_data` inpu
         self.report("INFO convergence check result: {}".format(on_track))
 
         return on_track
-
-
 
     def return_results(self):
         """
@@ -1132,8 +1301,8 @@ Can be skipped if a previous KkrCalculation is given with the `remote_data` inpu
             try:
                 all_pks.append(calc.pk)
             except:
-                self.ctx.warnings.append('cound not get pk of calc {}'.format(calc))
-
+                self.ctx.warnings.append(
+                    "cound not get pk of calc {}".format(calc))
 
         # capture links to last parameter, calcualtion and output
         try:
@@ -1177,78 +1346,101 @@ Can be skipped if a previous KkrCalculation is given with the `remote_data` inpu
         # now collect results saved in results node of workflow
         self.report("INFO: collect outputnode_dict")
         outputnode_dict = {}
-        outputnode_dict['workflow_name'] = self.__class__.__name__
-        outputnode_dict['workflow_version'] = self._workflowversion
-        outputnode_dict['material'] = self.ctx.formula
-        outputnode_dict['loop_count'] = self.ctx.loop_count
-        outputnode_dict['warnings'] = self.ctx.warnings
-        outputnode_dict['successful'] = self.ctx.successful
-        outputnode_dict['last_params_nodeinfo'] = {'uuid':last_params_uuid, 'pk':last_params_pk}
-        outputnode_dict['last_remote_nodeinfo'] = {'uuid':last_remote_uuid, 'pk':last_remote_pk}
-        outputnode_dict['last_calc_nodeinfo'] = {'uuid':last_calc_uuid, 'pk':last_calc_pk}
-        outputnode_dict['pks_all_calcs'] = all_pks
-        outputnode_dict['errors'] = self.ctx.errors
-        outputnode_dict['convergence_value'] = last_rms
-        outputnode_dict['convergence_values_all_steps'] = array(self.ctx.rms_all_steps)
-        outputnode_dict['convergence_values_last_step'] = array(self.ctx.last_rms_all)
-        outputnode_dict['charge_neutrality'] = last_neutr
-        outputnode_dict['charge_neutrality_all_steps'] = array(self.ctx.neutr_all_steps)
-        outputnode_dict['charge_neutrality_last_step'] = array(self.ctx.last_neutr_all)
-        outputnode_dict['dos_check_ok'] = self.ctx.dos_ok
-        outputnode_dict['convergence_reached'] = self.ctx.kkr_converged
-        outputnode_dict['voronoi_step_success'] = self.ctx.voro_step_success
-        outputnode_dict['kkr_step_success'] = self.ctx.kkr_step_success
-        outputnode_dict['used_higher_accuracy'] = self.ctx.kkr_higher_accuracy
+        outputnode_dict["workflow_name"] = self.__class__.__name__
+        outputnode_dict["workflow_version"] = self._workflowversion
+        outputnode_dict["material"] = self.ctx.formula
+        outputnode_dict["loop_count"] = self.ctx.loop_count
+        outputnode_dict["warnings"] = self.ctx.warnings
+        outputnode_dict["successful"] = self.ctx.successful
+        outputnode_dict["last_params_nodeinfo"] = {
+            "uuid": last_params_uuid, "pk": last_params_pk}
+        outputnode_dict["last_remote_nodeinfo"] = {
+            "uuid": last_remote_uuid, "pk": last_remote_pk}
+        outputnode_dict["last_calc_nodeinfo"] = {
+            "uuid": last_calc_uuid, "pk": last_calc_pk}
+        outputnode_dict["pks_all_calcs"] = all_pks
+        outputnode_dict["errors"] = self.ctx.errors
+        outputnode_dict["convergence_value"] = last_rms
+        outputnode_dict["convergence_values_all_steps"] = array(
+            self.ctx.rms_all_steps)
+        outputnode_dict["convergence_values_last_step"] = array(
+            self.ctx.last_rms_all)
+        outputnode_dict["charge_neutrality"] = last_neutr
+        outputnode_dict["charge_neutrality_all_steps"] = array(
+            self.ctx.neutr_all_steps)
+        outputnode_dict["charge_neutrality_last_step"] = array(
+            self.ctx.last_neutr_all)
+        outputnode_dict["dos_check_ok"] = self.ctx.dos_ok
+        outputnode_dict["convergence_reached"] = self.ctx.kkr_converged
+        outputnode_dict["voronoi_step_success"] = self.ctx.voro_step_success
+        outputnode_dict["kkr_step_success"] = self.ctx.kkr_step_success
+        outputnode_dict["used_higher_accuracy"] = self.ctx.kkr_higher_accuracy
 
         # report the status
         if self.ctx.successful:
-            self.report('STATUS: Done, the convergence criteria are reached.\n'
-                        'INFO: The charge density of the KKR calculation pk= {} '
-                        'converged after {} KKR runs and {} iterations to {} \n'
-                        ''.format(last_calc_pk, self.ctx.loop_count, self.ctx.loop_count, last_rms))
-        else: # Termination ok, but not converged yet...
-            if self.ctx.abort: # some error occured, donot use the output.
-                self.report('STATUS/ERROR: I abort, see logs and '
-                            'erros/warning/hints in output_kkr_scf_wc_para')
+            self.report(
+                "STATUS: Done, the convergence criteria are reached.\n"
+                "INFO: The charge density of the KKR calculation pk= {} "
+                "converged after {} KKR runs and {} iterations to {} \n"
+                "".format(
+                    last_calc_pk, self.ctx.loop_count,
+                    self.ctx.loop_count, last_rms
+                )
+            )
+        else:  # Termination ok, but not converged yet...
+            if self.ctx.abort:  # some error occured, donot use the output.
+                self.report(
+                    "STATUS/ERROR: I abort, see logs and "
+                    "erros/warning/hints in output_kkr_scf_wc_para"
+                )
             else:
-                self.report('STATUS/WARNING: Done, the maximum number of runs '
-                            'was reached or something failed.\n INFO: The '
-                            'charge density of the KKR calculation pk= '
-                            'after {} KKR runs and {} iterations is {} "me/bohr^3"\n'
-                            ''.format(self.ctx.loop_count, sum(self.ctx.KKR_steps_stats.get('isteps')), last_rms))
+                self.report(
+                    "STATUS/WARNING: Done, the maximum number of runs "
+                    "was reached or something failed.\n INFO: The "
+                    "charge density of the KKR calculation pk= "
+                    "after {} KKR runs and {} iterations is {} 'me/bohr^3'\n"
+                    "".format(
+                        self.ctx.loop_count,
+                        sum(self.ctx.KKR_steps_stats.get("isteps")), last_rms
+                    )
+                )
 
         # create results  node
-        self.report("INFO: create results node") #: {}".format(outputnode_dict))
+        # : {}".format(outputnode_dict))
+        self.report("INFO: create results node")
         outputnode_t = Dict(dict=outputnode_dict)
-        outputnode_t.label = 'kkr_scf_wc_results'
-        outputnode_t.description = 'Contains results of workflow (e.g. workflow version number, info about success of wf, lis tof warnings that occured during execution, ...)'
-
+        outputnode_t.label = "kkr_scf_wc_results"
+        outputnode_t.description = (
+            "Contains results of workflow"
+            " (e.g. workflow version number, info about success of wf,"
+            " lis tof warnings that occured during execution, ...)"
+        )
 
         # collect nodes in outputs dictionary
-        out_nodes = {'outpara': outputnode_t}
+        out_nodes = {"outpara": outputnode_t}
         if last_calc_out is not None:
-                out_nodes['last_calc_out'] = last_calc_out
+            out_nodes["last_calc_out"] = last_calc_out
         if last_RemoteData is not None:
-                out_nodes['last_RemoteData'] = last_RemoteData
+            out_nodes["last_RemoteData"] = last_RemoteData
         if last_InputParameters is not None:
-                out_nodes['last_InputParameters'] = last_InputParameters
+            out_nodes["last_InputParameters"] = last_InputParameters
         if final_dosdata_interpol is not None:
-                out_nodes['final_dosdata_interpol'] = final_dosdata_interpol
+            out_nodes["final_dosdata_interpol"] = final_dosdata_interpol
         if starting_dosdata_interpol is not None:
-                out_nodes['starting_dosdata_interpol'] = starting_dosdata_interpol
+            out_nodes["starting_dosdata_interpol"] = starting_dosdata_interpol
         if results_vorostart is not None:
-                out_nodes['results_vorostart'] = results_vorostart
-        if 'initial_noco_angles' in self.inputs:
-            if not all(self.ctx.initial_noco_angles['fix_dir']):
-                out_nodes['last_noco_angles'] = self.ctx.initial_noco_angles # was updated in inspect_kkr to last noco angles output
-                
+            out_nodes["results_vorostart"] = results_vorostart
+        if "initial_noco_angles" in self.inputs:
+            if not all(self.ctx.initial_noco_angles["fix_dir"]):
+                # was updated in inspect_kkr to last noco angles output
+                out_nodes["last_noco_angles"] = self.ctx.initial_noco_angles
+
         # call helper function to create output nodes in correct AiiDA graph structure
         outdict = create_scf_result_node(**out_nodes)
 
         for link_name, node in outdict.items():
             #self.report("INFO: storing node {} {} with linkname {}".format(type(node), node, link_name))
             self.out(link_name, node)
-
 
         # print results table for overview
         # table layout:
@@ -1257,18 +1449,33 @@ Can be skipped if a previous KkrCalculation is given with the `remote_data` inpu
         message += "| irun | success | isteps | imix | mixfac | accuracy settings |       rms       | abs(neutrality) | pk and uuid \n"
         message += "|      |         |        |      |        | qbound  | higher? | first  |  last  | first  |  last  |             \n"
         message += "|------|---------|--------|------|--------|---------|---------|--------|--------|--------|--------|-------------\n"
-        #| %6i  | %9s     | %8i    | %6i  | %.2e   | %.3e    | %9s     | %.2e   |  %.2e  |  %.2e  |  %.2e  |
+        # | %6i  | %9s     | %8i    | %6i  | %.2e   | %.3e    | %9s     | %.2e   |  %.2e  |  %.2e  |  %.2e  |
         KKR_steps_stats = self.ctx.KKR_steps_stats
-        for irun in range(len(KKR_steps_stats.get('success'))):
-            KKR_steps_stats.get('first_neutr')[irun] = abs(KKR_steps_stats.get('first_neutr')[irun])
-            KKR_steps_stats.get('last_neutr')[irun] = abs(KKR_steps_stats.get('last_neutr')[irun])
-            message += "|%6i|%9s|%8i|%6i|%.2e|%.3e|%9s|%.2e|%.2e|%.2e|%.2e|"%(irun+1,
-                          KKR_steps_stats.get('success')[irun], KKR_steps_stats.get('isteps')[irun],
-                          KKR_steps_stats.get('imix')[irun], KKR_steps_stats.get('mixfac')[irun],
-                          KKR_steps_stats.get('qbound')[irun], KKR_steps_stats.get('high_sett')[irun],
-                          KKR_steps_stats.get('first_rms')[irun], KKR_steps_stats.get('last_rms')[irun],
-                          KKR_steps_stats.get('first_neutr')[irun], KKR_steps_stats.get('last_neutr')[irun])
-            message += " {} | {}\n".format(KKR_steps_stats.get('pk')[irun], KKR_steps_stats.get('uuid')[irun])
+        for irun in range(len(KKR_steps_stats.get("success"))):
+            KKR_steps_stats.get("first_neutr")[irun] = abs(
+                KKR_steps_stats.get("first_neutr")[irun])
+            KKR_steps_stats.get("last_neutr")[irun] = abs(
+                KKR_steps_stats.get("last_neutr")[irun])
+            message += (
+                "|{:6d}|{:9s}|{:8d}|{:6d}|{:.2e}|{:.3e}|{:9s}|{:.2e}|{:.2e}|{:.2e}|{:.2e}|"
+                .format(
+                    irun+1,
+                    str(KKR_steps_stats.get("success")[irun]),
+                    KKR_steps_stats.get("isteps")[irun],
+                    KKR_steps_stats.get("imix")[irun],
+                    KKR_steps_stats.get("mixfac")[irun],
+                    KKR_steps_stats.get("qbound")[irun],
+                    str(KKR_steps_stats.get("high_sett")[irun]),
+                    KKR_steps_stats.get("first_rms")[irun],
+                    KKR_steps_stats.get("last_rms")[irun],
+                    KKR_steps_stats.get("first_neutr")[irun],
+                    KKR_steps_stats.get("last_neutr")[irun]
+                )
+            )
+            message += " {} | {}\n".format(
+                KKR_steps_stats.get("pk")[irun],
+                KKR_steps_stats.get("uuid")[irun]
+            )
             """
             message += "#|{}|{}|{}|{}|{}|{}|{}|{}|{}|{}|{}|\n".format(irun+1,
                           KKR_steps_stats.get('success')[irun], KKR_steps_stats.get('isteps')[irun],
@@ -1281,7 +1488,6 @@ Can be skipped if a previous KkrCalculation is given with the `remote_data` inpu
 
         self.report("\nINFO: done with kkr_scf workflow!\n")
 
-
     def check_input_params(self, params, is_voronoi=False):
         """
         Checks input parameter consistency and aborts wf if check fails.
@@ -1291,7 +1497,7 @@ Can be skipped if a previous KkrCalculation is given with the `remote_data` inpu
         else:
             input_dict = params.get_dict()
             if is_voronoi:
-                para_check = kkrparams(params_type='voronoi')
+                para_check = kkrparams(params_type="voronoi")
             else:
                 para_check = kkrparams()
 
@@ -1310,9 +1516,9 @@ Can be skipped if a previous KkrCalculation is given with the `remote_data` inpu
                     if key not in kkrparams.get_KKRcalc_parameter_defaults()[0]:
                         all_defaults = False
                 if not all_defaults:
-                    self.report('ERROR: calc_parameters given are not consistent! Missing mandatory keys: {}'.format(missing_list))
+                    self.report(
+                        "ERROR: calc_parameters given are not consistent! Missing mandatory keys: {}".format(missing_list))
                     return self.exit_codes.ERROR_CALC_PARAMETERS_INCOMPLETE
-
 
     def get_dos(self):
         """
@@ -1324,32 +1530,51 @@ Can be skipped if a previous KkrCalculation is given with the `remote_data` inpu
             # fix emin/emax to include emin, ef of scf contour
             # remember: efermi, emin and emax are in internal units (Ry) but delta_e is in eV!
             eV2Ry = 1./get_Ry2eV()
-            emin = self.ctx.dos_params['emin'] # from dos params
-            emin_cont = self.ctx.last_calc.outputs.output_parameters.get_dict().get('energy_contour_group').get('emin') # from contour (sets limit of dos emin!)
+            emin = self.ctx.dos_params["emin"]  # from dos params
+            emin_cont = self.ctx.last_calc.outputs.output_parameters.get_dict().get(
+                "energy_contour_group").get("emin")  # from contour (sets limit of dos emin!)
             if emin_cont - self.ctx.delta_e*eV2Ry < emin:
-                self.ctx.dos_params['emin'] = emin_cont - self.ctx.delta_e*eV2Ry
-                self.report("INFO: emin ({} Ry) - delta_e ({} Ry) smaller than emin ({} Ry) of voronoi output. Setting automatically to {}Ry".format(emin_cont, self.ctx.delta_e*eV2Ry,  emin, emin_cont-self.ctx.delta_e*eV2Ry))
-            self.ctx.efermi = get_ef_from_potfile(self.ctx.last_calc.outputs.retrieved.open('out_potential'))
-            emax = self.ctx.dos_params['emax']
+                self.ctx.dos_params["emin"] = (
+                    emin_cont - self.ctx.delta_e*eV2Ry
+                )
+                self.report(
+                    "INFO: emin ({} Ry) - delta_e ({} Ry) smaller than emin ({} Ry) of voronoi output. Setting automatically to {}Ry"
+                    .format(
+                        emin_cont, self.ctx.delta_e*eV2Ry, emin,
+                        emin_cont-self.ctx.delta_e*eV2Ry
+                    )
+                )
+            self.ctx.efermi = get_ef_from_potfile(
+                self.ctx.last_calc.outputs.retrieved.open("out_potential"))
+            emax = self.ctx.dos_params["emax"]
             if emax < self.ctx.efermi + self.ctx.delta_e*eV2Ry:
-                self.ctx.dos_params['emax'] = self.ctx.efermi + self.ctx.delta_e*eV2Ry
-                self.report("INFO: self.ctx.efermi ({} Ry) + delta_e ({} Ry) larger than emax ({} Ry). Setting automatically to {}Ry".format(self.ctx.efermi, self.ctx.delta_e*eV2Ry, emax, self.ctx.efermi+self.ctx.delta_e*eV2Ry))
+                self.ctx.dos_params["emax"] = self.ctx.efermi + \
+                    self.ctx.delta_e*eV2Ry
+                self.report(
+                    "INFO: self.ctx.efermi ({} Ry) + delta_e ({} Ry) larger than emax ({} Ry). Setting automatically to {}Ry"
+                    .format(
+                        self.ctx.efermi, self.ctx.delta_e*eV2Ry, emax,
+                        self.ctx.efermi+self.ctx.delta_e*eV2Ry
+                    )
+                )
 
             # take subset of input and prepare parameter node for dos workflow
-            wfdospara_dict = {'queue_name' : self.ctx.queue,
-                              'resources': self.ctx.resources,
-                              'max_wallclock_seconds' : self.ctx.max_wallclock_seconds,
-                              'withmpi' : self.ctx.withmpi,
-                              'custom_scheduler_commands' : self.ctx.custom_scheduler_commands,
-                              'dos_params' : self.ctx.dos_params}
+            wfdospara_dict = {
+                "queue_name": self.ctx.queue,
+                "resources": self.ctx.resources,
+                "max_wallclock_seconds": self.ctx.max_wallclock_seconds,
+                "withmpi": self.ctx.withmpi,
+                "custom_scheduler_commands": self.ctx.custom_scheduler_commands,
+                "dos_params": self.ctx.dos_params
+            }
             wfdospara_node = Dict(dict=wfdospara_dict)
-            wfdospara_node.label = 'DOS params'
-            wfdospara_node.description = 'DOS parameter set for final DOS calculation of kkr_scf_wc'
+            wfdospara_node.label = "DOS params"
+            wfdospara_node.description = "DOS parameter set for final DOS calculation of kkr_scf_wc"
 
             code = self.inputs.kkr
             remote = self.ctx.last_calc.outputs.remote_folder
-            wf_label= ' final DOS calculation'
-            wf_desc = ' subworkflow of a DOS calculation'
+            wf_label = " final DOS calculation"
+            wf_desc = " subworkflow of a DOS calculation"
 
             builder = kkr_dos_wc.get_builder()
             builder.metadata.description = wf_desc
@@ -1363,7 +1588,6 @@ Can be skipped if a previous KkrCalculation is given with the `remote_data` inpu
 
             return ToContext(doscal=future)
 
-
     def check_dos(self):
         """
         checks if dos of final potential is ok
@@ -1376,38 +1600,46 @@ Can be skipped if a previous KkrCalculation is given with the `remote_data` inpu
             self.report("INFO: skipping DOS check")
             return
 
-        self.report("INFO: checking DOS for consistency (EMIN position, negative DOS, etc.)")
+        self.report(
+            "INFO: checking DOS for consistency (EMIN position, negative DOS, etc.)")
 
         # check parser output
         doscal = self.ctx.doscal
         try:
             dos_outdict = doscal.outputs.results_wf.get_dict()
-            if not dos_outdict['successful']:
+            if not dos_outdict["successful"]:
                 self.report("ERROR: DOS workflow unsuccessful")
                 self.ctx.dos_ok = False
-                return self.exit_codes.ERROR_DOS_RUN_UNSUCCESFUL
+                return self.exit_codes.ERROR_DOS_RUN_UNSUCCESSFUL
 
-            if dos_outdict['list_of_errors'] != []:
-                self.report("ERROR: DOS wf output contains errors: {}".format(dos_outdict['list_of_errors']))
+            if dos_outdict["list_of_errors"] != []:
+                self.report(
+                    "ERROR: DOS wf output contains errors: {}"
+                    .format(dos_outdict["list_of_errors"])
+                )
                 self.ctx.dos_ok = False
-                return self.exit_codes.ERROR_DOS_RUN_UNSUCCESFUL
+                return self.exit_codes.ERROR_DOS_RUN_UNSUCCESSFUL
         except AttributeError:
             self.ctx.dos_ok = False
-            return self.exit_codes.ERROR_DOS_RUN_UNSUCCESFUL
+            return self.exit_codes.ERROR_DOS_RUN_UNSUCCESSFUL
 
         # check for negative DOS
         try:
             dosdata = doscal.outputs.dos_data
-            natom = self.ctx.last_calc.outputs.output_parameters.get_dict()['number_of_atoms_in_unit_cell']
-            nspin = dos_outdict['nspin']
+            natom = self.ctx.last_calc.outputs.output_parameters.get_dict()[
+                "number_of_atoms_in_unit_cell"]
+            nspin = dos_outdict["nspin"]
 
-            ener = dosdata.get_x()[1] # shape= natom*nspin, nept
-            totdos = dosdata.get_y()[0][1] # shape= natom*nspin, nept
+            ener = dosdata.get_x()[1]  # shape= natom*nspin, nept
+            totdos = dosdata.get_y()[0][1]  # shape= natom*nspin, nept
 
             if len(ener) != nspin*natom:
-                self.report("ERROR: DOS output shape does not fit nspin, natom information: len(energies)={}, natom={}, nspin={}".format(len(ener), natom, nspin))
+                self.report(
+                    "ERROR: DOS output shape does not fit nspin, natom information: len(energies)={}, natom={}, nspin={}"
+                    .format(len(ener), natom, nspin)
+                )
                 self.ctx.doscheck_ok = False
-                return self.exit_codes.ERROR_DOS_RUN_UNSUCCESFUL
+                return self.exit_codes.ERROR_DOS_RUN_UNSUCCESSFUL
 
             # deal with snpin==1 or 2 cases and check negtive DOS
             for iatom in range(natom//nspin):
@@ -1416,28 +1648,34 @@ Can be skipped if a previous KkrCalculation is given with the `remote_data` inpu
                     if nspin == 2 and ispin == 0:
                         y = -y
                     if y.min() < 0:
-                        self.report("INFO: negative DOS value found in (atom, spin)=({},{}) at iteration {}: {}".format(iatom, ispin, self.ctx.loop_count, y.min()))
+                        self.report(
+                            "INFO: negative DOS value found in (atom, spin)=({},{}) at iteration {}: {}"
+                            .format(iatom, ispin, self.ctx.loop_count, y.min())
+                        )
                         self.ctx.dos_ok = False
 
             # check starting EMIN
             dosdata_interpol = doscal.outputs.dos_data_interpol
 
-            ener = dosdata_interpol.get_x()[1] # shape= natom*nspin, nept
-            totdos = dosdata_interpol.get_y()[0][1] # shape= natom*nspin, nept
+            ener = dosdata_interpol.get_x()[1]  # shape= natom*nspin, nept
+            totdos = dosdata_interpol.get_y()[0][1]  # shape= natom*nspin, nept
             Ry2eV = get_Ry2eV()
 
             for iatom in range(natom//nspin):
                 for ispin in range(nspin):
                     x, y = ener[iatom*nspin+ispin], totdos[iatom*nspin+ispin]
-                    xrel = abs(x-(self.ctx.dos_params_dict['emin']-self.ctx.efermi)*Ry2eV)
-                    mask_emin = where(xrel==xrel.min())
+                    xrel = abs(
+                        x-(self.ctx.dos_params_dict["emin"]-self.ctx.efermi)*Ry2eV)
+                    mask_emin = where(xrel == xrel.min())
                     ymin = abs(y[mask_emin])
                     if ymin > self.ctx.threshold_dos_zero:
-                        self.report("INFO: DOS at emin not zero! {}>{}".format(ymin,self.ctx.threshold_dos_zero))
+                        self.report(
+                            "INFO: DOS at emin not zero! {}>{}"
+                            .format(ymin, self.ctx.threshold_dos_zero)
+                        )
                         self.ctx.dos_ok = False
         except AttributeError:
             self.ctx.dos_ok = False
-
 
     def _get_new_noco_angles(self):
         """
@@ -1445,15 +1683,15 @@ Can be skipped if a previous KkrCalculation is given with the `remote_data` inpu
         Here we update self.ctx.initial_noco_angles with the new values
         """
         # first check if we need to update the angles
-        if all(self.ctx.initial_noco_angles['fix_dir']):
+        if all(self.ctx.initial_noco_angles["fix_dir"]):
             return
-        
+
         # extract output angles from last calculation and update initial_noco_angles in context
-        self.ctx.initial_noco_angles = extract_noco_angles(fix_dir_threshold=Float(self.ctx.fix_dir_threshold),
-                                                           old_noco_angles=self.ctx.initial_noco_angles,
-                                                           last_retrieved=self.ctx.last_calc.outputs.retrieved
-                                                          )
-            
+        self.ctx.initial_noco_angles = extract_noco_angles(
+            fix_dir_threshold=Float(self.ctx.fix_dir_threshold),
+            old_noco_angles=self.ctx.initial_noco_angles,
+            last_retrieved=self.ctx.last_calc.outputs.retrieved
+        )
 
 
 @calcfunction
@@ -1463,23 +1701,37 @@ def extract_noco_angles(**kwargs):
     New angles are compared to old angles and if they are closer thanfix_dir_threshold they are not allowed to change anymore
     """
     # for comparison read previous theta and phi values and the threshold after which the moments are kept fixed
-    noco_angles_old = kwargs['old_noco_angles'].get_dict()
-    natom = len(noco_angles_old['phi'])
-    noco_angles_old = [[noco_angles_old['theta'][i], noco_angles_old['phi'][i], noco_angles_old['fix_dir'][i]] for i in range(natom)]
-    fix_dir_threshold = kwargs['fix_dir_threshold'].value
-    
-    last_retrieved = kwargs['last_retrieved']
+    noco_angles_old = kwargs["old_noco_angles"].get_dict()
+    natom = len(noco_angles_old["phi"])
+    noco_angles_old = [
+        [
+            noco_angles_old["theta"][i],
+            noco_angles_old["phi"][i],
+            noco_angles_old["fix_dir"][i]
+        ] for i in range(natom)
+    ]
+    fix_dir_threshold = kwargs["fix_dir_threshold"].value
+
+    last_retrieved = kwargs["last_retrieved"]
     noco_out_name = KkrCalculation._NONCO_ANGLES_OUT
     if noco_out_name in last_retrieved.list_object_names():
         with last_retrieved.open(noco_out_name) as noco_file:
-            noco_angles_new = loadtxt(noco_file, usecols=[0,1])
+            noco_angles_new = loadtxt(noco_file, usecols=[0, 1])
             # check if theta and phi change less than fix_dir_threshold
-            fix_dir = [sqrt((noco_angles_new[i][0]-noco_angles_old[i][0])**2+(noco_angles_new[i][1]-noco_angles_old[i][1])**2)<fix_dir_threshold for i in range(natom)]
-            new_initial_noco_angles = Dict(dict={
-                'theta': list(noco_angles_new[:,0]),
-                'phi': list(noco_angles_new[:,1]),
-                'fix_dir': [bool(i) for i in fix_dir] # convert from numpy.bool_ to standard python bool, otherwise this is not json serializable and cannot be stored
-            })
+            fix_dir = [
+                sqrt(
+                    (noco_angles_new[i][0]-noco_angles_old[i][0])**2
+                    + (noco_angles_new[i][1]-noco_angles_old[i][1])**2
+                ) < fix_dir_threshold for i in range(natom)
+            ]
+            new_initial_noco_angles = Dict(
+                dict={
+                    "theta": list(noco_angles_new[:, 0]),
+                    "phi": list(noco_angles_new[:, 1]),
+                    # convert from numpy.bool_ to standard python bool, otherwise this is not json serializable and cannot be stored
+                    "fix_dir": [bool(i) for i in fix_dir]
+                }
+            )
         return new_initial_noco_angles
 
 
@@ -1502,25 +1754,25 @@ def create_scf_result_node(**kwargs):
     has_last_InputParameters = False
 
     for key, val in kwargs.items():
-        if key == 'outpara': #  should always be there
+        if key == "outpara":  # should always be there
             outpara = val
             has_last_outpara = True
-        elif key == 'last_calc_out':
+        elif key == "last_calc_out":
             has_last_calc_out_dict = True
             last_calc_out_dict = val
-        elif key == 'last_RemoteData':
+        elif key == "last_RemoteData":
             last_RemoteData_dict = val
             has_last_RemoteData = True
-        elif key == 'last_InputParameters':
+        elif key == "last_InputParameters":
             last_InputParameters_dict = val
             has_last_InputParameters = True
-        elif key == 'results_vorostart':
+        elif key == "results_vorostart":
             has_vorostart_output = True
             vorostart_output_dict = val
-        elif key == 'starting_dosdata_interpol':
+        elif key == "starting_dosdata_interpol":
             has_starting_dos = True
             start_dosdata_interpol_dict = val
-        elif key == 'final_dosdata_interpol':
+        elif key == "final_dosdata_interpol":
             has_final_dos = True
             final_dosdata_interpol_dict = val
 
@@ -1528,51 +1780,65 @@ def create_scf_result_node(**kwargs):
 
     if has_last_outpara:
         outputnode = outpara
-        outputnode.label = 'workflow_Results'
-        outputnode.description = ('Contains self-consistency results and '
-                                  'information of an kkr_scf_wc run.')
-        outdict['output_kkr_scf_wc_ParameterResults'] = outputnode
+        outputnode.label = "workflow_Results"
+        outputnode.description = (
+            "Contains self-consistency results and "
+            "information of an kkr_scf_wc run."
+        )
+        outdict["output_kkr_scf_wc_ParameterResults"] = outputnode
 
     if has_last_calc_out_dict:
         outputnode = last_calc_out_dict
-        outputnode.label = 'last_calc_out'
-        outputnode.description = ('Contains the Results Parameter node from the output '
-                                   'of the last calculation done in the workflow.')
-        outdict['last_calc_out'] = outputnode
+        outputnode.label = "last_calc_out"
+        outputnode.description = (
+            "Contains the Results Parameter node from the output "
+            "of the last calculation done in the workflow."
+        )
+        outdict["last_calc_out"] = outputnode
 
     if has_last_RemoteData:
         outputnode = last_RemoteData_dict
-        outputnode.label = 'last_RemoteData'
-        outputnode.description = ('Contains a link to the latest remote data node '
-                                   'where the output of the calculation can be accessed.')
-        outdict['last_RemoteData'] = outputnode
+        outputnode.label = "last_RemoteData"
+        outputnode.description = (
+            "Contains a link to the latest remote data node "
+            "where the output of the calculation can be accessed."
+        )
+        outdict["last_RemoteData"] = outputnode
 
     if has_last_InputParameters:
         outputnode = last_InputParameters_dict
-        outputnode.label = 'last_InputParameters'
-        outputnode.description = ('Contains the latest parameter data node '
-                                   'where the input of the last calculation can be found.')
-        outdict['last_InputParameters'] = outputnode
+        outputnode.label = "last_InputParameters"
+        outputnode.description = (
+            "Contains the latest parameter data node "
+            "where the input of the last calculation can be found."
+        )
+        outdict["last_InputParameters"] = outputnode
 
     if has_vorostart_output:
         outputnode = vorostart_output_dict
-        outputnode.label = 'results_vorostart'
-        outputnode.description = ('Contains the results parameter data node '
-                                   'of the vorostart sub-workflow (sets up starting portentials).')
-        outdict['results_vorostart'] = outputnode
+        outputnode.label = "results_vorostart"
+        outputnode.description = (
+            "Contains the results parameter data node "
+            "of the vorostart sub-workflow (sets up starting portentials)."
+        )
+        outdict["results_vorostart"] = outputnode
 
     if has_starting_dos:
         outputnode = start_dosdata_interpol_dict
-        outputnode.label = 'starting_dosdata_interpol'
-        outputnode.description = ('Contains the interpolated DOS data note, computed '
-                                   'from the starting portential.')
-        outdict['starting_dosdata_interpol'] = outputnode
+        outputnode.label = "starting_dosdata_interpol"
+        outputnode.description = (
+            "Contains the interpolated DOS data note, computed "
+            "from the starting portential."
+        )
+        outdict["starting_dosdata_interpol"] = outputnode
 
     if has_final_dos:
         outputnode = final_dosdata_interpol_dict
-        outputnode.label = 'final_dosdata_interpol'
-        outputnode.description = ('Contains the interpolated DOS data note, computed '
-                                   'from the converged potential.')
-        outdict['final_dosdata_interpol'] = outputnode
+        outputnode.label = "final_dosdata_interpol"
+        outputnode.description = (
+            "Contains the interpolated DOS data note, computed "
+            "from the converged potential."
+        )
+        outdict["final_dosdata_interpol"] = outputnode
 
     return outdict

--- a/aiida_kkr/workflows/voro_start.py
+++ b/aiida_kkr/workflows/voro_start.py
@@ -49,21 +49,23 @@ class kkr_startpot_wc(WorkChain):
     """
 
     _workflowversion = __version__
-    _wf_default = {'num_rerun' : 4,                          # number of times voronoi+starting dos+checks is rerun to ensure non-negative DOS etc
-                   'fac_cls_increase' : 1.15, # alat         # factor by which the screening cluster is increased each iteration (up to num_rerun times)
-                   'natom_in_cls_min' : 79,                  # minimum number of atoms in screening cluster
-                   'delta_e_min' : 1., # eV                  # minimal distance in DOS contour to emin and emax in eV
-                   'threshold_dos_zero' : 10**-2, #states/eV #
-                   'check_dos': False,                       # logical to determine if DOS is computed and checked
-                   'delta_e_min_core_states': 0.2, # Ry      # minimal distance of start of energy contour to highest lying core state in Ry
-                   'ef_set': None                            # set Fermi level of starting potential to this value
-                   }
-    _options_default = {'queue_name' : '',                        # Queue name to submit jobs to
-                        'resources': {"num_machines": 1},         # resources to allowcate for the job
-                        'max_wallclock_seconds' : 60*60,          # walltime after which the job gets killed (gets parsed to KKR)
-                        'withmpi' : True,                         # execute KKR with mpi or without
-                        'custom_scheduler_commands' : '',         # some additional scheduler commands
-                        }
+    _wf_default = {
+        'num_rerun': 4,                          # number of times voronoi+starting dos+checks is rerun to ensure non-negative DOS etc
+        'fac_cls_increase' : 1.15, # alat         # factor by which the screening cluster is increased each iteration (up to num_rerun times)
+        'natom_in_cls_min' : 79,                  # minimum number of atoms in screening cluster
+        'delta_e_min' : 1., # eV                  # minimal distance in DOS contour to emin and emax in eV
+        'threshold_dos_zero' : 10**-2, #states/eV #
+        'check_dos': False,                       # logical to determine if DOS is computed and checked
+        'delta_e_min_core_states': 0.2, # Ry      # minimal distance of start of energy contour to highest lying core state in Ry
+        'ef_set': None                            # set Fermi level of starting potential to this value
+        }
+    _options_default = {
+        'queue_name' : '',                        # Queue name to submit jobs to
+        'resources': {"num_machines": 1},         # resources to allowcate for the job
+        'max_wallclock_seconds' : 60*60,          # walltime after which the job gets killed (gets parsed to KKR)
+        'withmpi' : True,                         # execute KKR with mpi or without
+        'custom_scheduler_commands' : '',         # some additional scheduler commands
+        }
     # add defaults of dos_params since they are passed onto that workflow
     for key, value in kkr_dos_wc.get_wf_defaults(silent=True).items():
         if key == 'dos_params':
@@ -373,9 +375,9 @@ class kkr_startpot_wc(WorkChain):
             gmax_input = default_values.get('GMAX')
         # check if any mandatory keys are not set and set them with the default values if missing in input parameters
         for key, value in default_values.items():
-          if key not in update_list and key not in set_vals:
-              self.report("INFO: setting {} to default value {}".format(key, value))
-              kkr_para.set_value(key, value)
+            if key not in update_list and key not in set_vals:
+                self.report("INFO: setting {} to default value {}".format(key, value))
+                kkr_para.set_value(key, value)
 
         # check if Fermi lavel should be set with input value
         if self.ctx.ef_set is not None:
@@ -581,11 +583,13 @@ class kkr_startpot_wc(WorkChain):
         if self.ctx.check_dos:
             self.report("INFO: Doing DOS calculation in iteration {}".format(self.ctx.iter))
             # take subset of input and prepare parameter node for dos workflow
-            options_dict =  {'queue_name' : self.ctx.queue,
-                             'resources': self.ctx.resources,
-                             'max_wallclock_seconds' : self.ctx.max_wallclock_seconds,
-                             'withmpi' : self.ctx.withmpi,
-                             'custom_scheduler_commands' : self.ctx.custom_scheduler_commands}
+            options_dict = {
+                'queue_name' : self.ctx.queue,
+                'resources': self.ctx.resources,
+                'max_wallclock_seconds' : self.ctx.max_wallclock_seconds,
+                'withmpi' : self.ctx.withmpi,
+                'custom_scheduler_commands' : self.ctx.custom_scheduler_commands
+                }
             options_node = Dict(dict=options_dict)
             options_node.label = 'options'
             wfdospara_dict = {'dos_params' : self.ctx.dos_params_dict}

--- a/examples/kkr_submit_scf.py
+++ b/examples/kkr_submit_scf.py
@@ -1,0 +1,113 @@
+"""
+Example calculation of fcc Cu making use of the SCF workchain for the kkrhost
+code.
+"""
+import ase.spacegroup
+from aiida import orm
+from aiida.engine import submit
+from masci_tools.io.kkr_params import kkrparams
+from aiida_kkr.workflows.kkr_scf import kkr_scf_wc
+
+
+def create_fcc_cu(a_lat=lambda: orm.Float(3.6142)) -> orm.StructureData:
+    """
+    Function to generate a fcc Cu structure
+
+    The function also makes sure that the formula and the space group number
+    are stored in the extras so that they can be more easily queried via the
+    QueryBuilder.
+
+    :param a_lat: lattice parameter for fcc Cu, defaults to lambda:orm.Float(3.6142)
+    :type a_lat: [type], optional
+    """
+    # Get the lattice distance for the fcc lattice
+    alat = 0.5*a_lat.value
+    structure = orm.StructureData(
+        cell=[[alat, alat, 0.0], [alat, 0.0, alat], [0.0, alat, alat]]
+    )
+    # Add the positions of the atoms in the unitcell
+    structure.append_atom(position=[0.0, 0.0, 0.0], symbols='Cu')
+
+    # Get the spacegroup information of the unitcell
+    sg = ase.spacegroup.get_spacegroup(structure.get_ase())
+
+    # Storing the formula as an extra so that it can easily be found
+    structure.set_extra('formula', structure.get_formula(mode='count'))
+    # Storing the spacegroup number so that it can be easily found
+    structure.set_extra('space_group_number', sg.no)
+
+    return structure
+
+
+def generate_kkr_parameters(input_parameters):
+    """
+    Function to generate a dictionary with the parameters needed for a
+    kkrhost run. It overwrites the default parameters with the provided
+    parameters
+    """
+    kkr_calculation_parameters = kkrparams(**input_parameters)
+
+    return kkr_calculation_parameters
+
+
+def main():
+    """
+    Main function to run an SCF run using the kkrhost code
+    """
+    # Define the KKR code via the code string
+    kkr_code = orm.load_code("jukkr-host-intel@moggie")
+    # Define the Voronoi code via the code string
+    voronoi_code = orm.load_code("jukkr-voronoi-intel@moggie")
+
+    # Generate the fcc Cu structure that will be used for the calculation
+    fcc_structure = create_fcc_cu(a_lat=orm.Float(3.6142))
+
+    # Generate a dictionary with the necessary parameters for the kkrhost
+    # calculation
+    kkr_calculation_parameters = generate_kkr_parameters(
+        input_parameters={
+            'LMAX': 2, 'RMAX': 7, 'GMAX': 65, 'NSPIN': 1, 'RCLUSTZ': 1.9
+        }
+    )
+
+    # Setting parameters for the submission of the job
+    options = {
+        'resources': {
+            # Total number of mpi processes
+            'tot_num_mpiprocs': 16,
+            # Name of the parallel environment
+            'parallel_env': 'mpi',
+        },
+        # Maximum allowed execution time in seconds
+        'max_wallclock_seconds': 18000,
+        # Whether to run in parallel
+        'withmpi': True,
+        # Name of the slot used (execute [2 cores], large [16 cores],
+        # hpc [16 cores], fat [16 cores high memory], hpcc [44 cores],
+        # hpcb [60 cores], hpcfat [16 cores high memory],
+        # gpu [6 cores + graphic card])
+        'custom_scheduler_commands': '#$ -l slot_type=hpc'
+    }
+
+    # Setting a label for the calculation
+    label = "JM-KKR_host_fcc_Cu"
+    # Provide a more lengthy description of the actual calculation
+    description = "Test FCC Cu SCF calculation with the JM-KKR host code"
+
+    # Populate the inputs of the kkrhost code
+    builder = kkr_scf_wc.get_builder()
+    builder.kkr = kkr_code
+    builder.voronoi = voronoi_code
+    builder.options = orm.Dict(dict=options)
+    builder.structure = fcc_structure
+    builder.calc_parameters = orm.Dict(dict=kkr_calculation_parameters)
+    builder.metadata.label = label
+    builder.metadata.description = description
+
+    # Submit the calculation to the daemon
+    submission = submit(builder)
+    print("SCF calculation submitted with pk {}".format(submission.pk))
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/kkr_submit_scf.py
+++ b/examples/kkr_submit_scf.py
@@ -55,9 +55,9 @@ def main():
     Main function to run an SCF run using the kkrhost code
     """
     # Define the KKR code via the code string
-    kkr_code = orm.load_code("jukkr-host-intel@moggie")
+    kkr_code = orm.load_code("jukkr-host@dummy")
     # Define the Voronoi code via the code string
-    voronoi_code = orm.load_code("jukkr-voronoi-intel@moggie")
+    voronoi_code = orm.load_code("jukkr-voronoi@dummy")
 
     # Generate the fcc Cu structure that will be used for the calculation
     fcc_structure = create_fcc_cu(a_lat=orm.Float(3.6142))
@@ -82,11 +82,6 @@ def main():
         'max_wallclock_seconds': 18000,
         # Whether to run in parallel
         'withmpi': True,
-        # Name of the slot used (execute [2 cores], large [16 cores],
-        # hpc [16 cores], fat [16 cores high memory], hpcc [44 cores],
-        # hpcb [60 cores], hpcfat [16 cores high memory],
-        # gpu [6 cores + graphic card])
-        'custom_scheduler_commands': '#$ -l slot_type=hpc'
     }
 
     # Setting a label for the calculation

--- a/examples/kkr_submit_scf.py
+++ b/examples/kkr_submit_scf.py
@@ -70,19 +70,35 @@ def main():
         }
     )
 
-    # Setting parameters for the submission of the job
-    options = {
-        'resources': {
-            # Total number of mpi processes
-            'tot_num_mpiprocs': 16,
-            # Name of the parallel environment
-            'parallel_env': 'mpi',
-        },
-        # Maximum allowed execution time in seconds
-        'max_wallclock_seconds': 18000,
-        # Whether to run in parallel
-        'withmpi': True,
-    }
+    # For the SGE scheduler
+    if kkr_code.computer.scheduler_type in ["sge"]:
+        # Setting parameters for the submission of the job
+        options = {
+            'resources': {
+                # Total number of mpi processes
+                'tot_num_mpiprocs': 16,
+                # Name of the parallel environment
+                'parallel_env': 'mpi',
+            },
+            # Maximum allowed execution time in seconds
+            'max_wallclock_seconds': 18000,
+            # Whether to run in parallel
+            'withmpi': True,
+        }
+
+    # For slurm and pbs scheduler types
+    if kkr_code.computer.scheduler_type in ["slurm", "pbspro"]:
+        # Setting parameters for the submission of the job
+        options = {
+            'resources': {
+                # Total number of mpi processes
+                'num_machines': 1,
+            },
+            # Maximum allowed execution time in seconds
+            'max_wallclock_seconds': 18000,
+            # Whether to run in parallel
+            'withmpi': True,
+        }
 
     # Setting a label for the calculation
     label = "JM-KKR_host_fcc_Cu"


### PR DESCRIPTION
The plugin could not work as the `get_inputs_common` added submission options which are incompatible for the SGE scheduler. Now it checks which scheduler is provided and sets options which correspond to a serial simulation. Fixes #40 