### PR TITLE
Ignore deprecated kkrparam keys

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ __pycache__/
 .Python
 env/
 build/
+_build/
 develop-eggs/
 dist/
 downloads/
@@ -117,7 +118,7 @@ venv*/
 
 # VScode
 .idea/
-aiida_kkr/.vscode/
+.vscode/
 
 # testing files (test runs locally)
 aiida_kkr/tests/.aiida/

--- a/aiida_kkr/tools/common_workfunctions.py
+++ b/aiida_kkr/tools/common_workfunctions.py
@@ -16,7 +16,7 @@ from six.moves import range
 from builtins import str
 
 # keys that are used by aiida-kkr some something else than KKR parameters
-_ignored_keys = ['ef_set', 'use_input_alat']
+_ignored_keys = ['ef_set', 'use_input_alat', '<newversion_bdg>']
 _ignored_keys += [i.upper() for i in _ignored_keys]
 
 

--- a/aiida_kkr/tools/common_workfunctions.py
+++ b/aiida_kkr/tools/common_workfunctions.py
@@ -15,8 +15,11 @@ from masci_tools.io.common_functions import open_general
 from six.moves import range
 from builtins import str
 
-# keys that are used by aiida-kkr some something else than KKR parameters
-_ignored_keys = ['ef_set', 'use_input_alat', '<newversion_bdg>', '<decouple_spins_cheby>']
+# Ignored keys:
+# - Special keys that are used for special cases but are not part of the KKR parameter set.
+# - Keys which were part of the KKR parameter set in earlier masci-tools / aiida-kkr versions,
+#   but have been removed or renamed, and are included here for backwards compatibility.
+_ignored_keys = ['ef_set', 'use_input_alat', '<decouple_spins_cheby>', '<newversion_bdg>']
 _ignored_keys += [i.upper() for i in _ignored_keys]
 
 
@@ -100,8 +103,9 @@ def update_params(node, nodename=None, nodedesc=None, **kwargs):
     if not add_direct:
         for key in inp_params:
             if key not in list(params.values.keys()) and key not in _ignored_keys:
-                print(f'Input node contains invalid key "{key}"')
-                raise InputValidationError(f'invalid key "{key}" in input parameter node')
+                msg = f'Invalid key "{key}" in input calc_parameters node.'
+                print(msg)
+                raise InputValidationError(msg)
 
     # copy values from input node
     for key in inp_params:

--- a/aiida_kkr/tools/common_workfunctions.py
+++ b/aiida_kkr/tools/common_workfunctions.py
@@ -16,7 +16,7 @@ from six.moves import range
 from builtins import str
 
 # keys that are used by aiida-kkr some something else than KKR parameters
-_ignored_keys = ['ef_set', 'use_input_alat', '<newversion_bdg>']
+_ignored_keys = ['ef_set', 'use_input_alat', '<newversion_bdg>', '<decouple_spins_cheby>']
 _ignored_keys += [i.upper() for i in _ignored_keys]
 
 


### PR DESCRIPTION
The `kkrparams` class in `masci_tools/io/kkr_params.py` contains the defined keys for `calc_parameters` input nodes to aiida-kkr workflows. Recent changes to `kkrparams` removed deprecated keys ([commit 0686ad8](https://github.com/JuDFTteam/masci-tools/commit/0686ad8af367fd0144fe69f9419f7fa59b8b8da8) renamed key `<DECOUPLE_SPINS_CHEBY>` --> `<DECOUPLE_SPIN_CHEBY>`; [commit a5ffeed](https://github.com/JuDFTteam/masci-tools/commit/a5ffeed09e8e8d91e18da792c1e204802ec530e4#) removed key `<NEWVERSION_BDG>`).

The `update_params()` function in `aiida-kkr/aiida_kkr/tools/common_workfunctions.py` uses the set of `kkrparams` keys and a list `ignored_keys` defined in that module to check for unknown keys. If any are found, it throws an error.

This PR proposes to add the above deprecated keys to `ignored_keys`. The outcome would be that old workchains which still used these keys could be reused, rather than throwing an error.

No unwanted side effects are known, but this should be checker by the reviewer. The code has been tested with deprecated `kkr_scf_wc` workchains as inputs for new `kkr_imp_wc`. This failed without the PR, and worked with it.

----

(In addition, in top-level `.gitignore`, made ignore folders `.vscode` global and added global ignore `_build`.)